### PR TITLE
Remove es6 syntax that required babel deps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-  "stage": 0,
-  "loose": "all",
-  "plugins": ["object-assign"]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,4 @@
 {
-  "parser": "babel-eslint",
   "env": {
     "node": true,
     "browser": true

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
  * map.addControl(geocoder);
  * @return {Geocoder} `this`
  */
-import Geocoder from './src/geocoder';
+var Geocoder = require('./src/geocoder');
 
 if (window.mapboxgl) {
   mapboxgl.Geocoder = Geocoder;

--- a/package.json
+++ b/package.json
@@ -3,16 +3,10 @@
   "version": "0.0.0",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "index.js",
-  "browserify": {
-    "transform": [
-      "envify",
-      "babelify"
-    ]
-  },
   "scripts": {
     "start": "budo example/index.js --serve=example/bundle.js --live -d",
     "build": "NODE_ENV=production && browserify index.js | uglifyjs -c -m > dist/mapbox-gl-geocoder.js",
-    "test": "npm run lint && browserify test/index.js | smokestack -b firefox | tap-status",
+    "test": "npm run lint && browserify -t envify test/index.js | smokestack -b firefox | tap-status",
     "docs": "documentation --format=md > API.md",
     "lint": "eslint --no-eslintrc -c .eslintrc index.js src"
   },
@@ -32,9 +26,6 @@
   },
   "homepage": "https://github.com/mapbox/mapbox-gl-geocoder#readme",
   "devDependencies": {
-    "babel-eslint": "^4.0.10",
-    "babel-plugin-object-assign": "^1.2.1",
-    "babelify": "^6.4.0",
     "browserify": "^11.2.0",
     "budo": "^7.0.2",
     "documentation": "^3.0.0",
@@ -52,6 +43,7 @@
   "dependencies": {
     "lodash.debounce": "^3.1.1",
     "mapbox": "^0.11.0",
-    "suggestions": "^1.1.1"
+    "suggestions": "^1.1.1",
+    "xtend": "^4.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tape');
+var test = require('tape');
 window.mapboxgl = require('mapbox-gl');
 require('../');
 

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const test = require('tape');
-const once = require('lodash.once');
+var test = require('tape');
+var once = require('lodash.once');
 
-test('geocoder', (tt) => {
-  let container, map, geocoder;
+test('geocoder', function(tt) {
+  var container, map, geocoder;
 
   function setup(opts) {
     container = document.createElement('div');
@@ -13,23 +13,23 @@ test('geocoder', (tt) => {
     map.addControl(geocoder);
   }
 
-  tt.test('initialized', t => {
+  tt.test('initialized', function(t) {
     setup();
     t.ok(geocoder, 'geocoder is initialized');
     t.end();
   });
 
-  tt.test('set/get input', t => {
+  tt.test('set/get input', function(t) {
     t.plan(2);
     setup({ proximity: [-79.45, 43.65] });
     geocoder.query('Queen Street');
-    geocoder.on('geocoder.input', once((e) => {
+    geocoder.on('geocoder.input', once(function(e) {
       t.ok(geocoder.getResult(), 'feature is present from get');
       t.ok(e.result, 'feature is in the event object');
     }));
   });
 
-  tt.test('fire', t => {
+  tt.test('fire', function(t) {
     t.plan(2);
     setup();
 

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const once = require('lodash.once');
-const test = require('tape');
+var once = require('lodash.once');
+var test = require('tape');
 
-test('Geocoder#inputControl', tt => {
-  let container, map, geocoder;
+test('Geocoder#inputControl', function(tt) {
+  var container, map, geocoder;
 
-  const changeEvent = document.createEvent('HTMLEvents');
+  var changeEvent = document.createEvent('HTMLEvents');
   changeEvent.initEvent('change', true, false);
 
-  const clickEvent = document.createEvent('HTMLEvents');
+  var clickEvent = document.createEvent('HTMLEvents');
   clickEvent.initEvent('click', true, false);
 
   function setup(opts) {
@@ -19,39 +19,39 @@ test('Geocoder#inputControl', tt => {
     map.addControl(geocoder);
   }
 
-  tt.test('input', t => {
+  tt.test('input', function(t) {
     setup();
     t.plan(4);
     var inputEl = container.querySelector('.mapboxgl-ctrl-geocoder input');
     var clearEl = container.querySelector('.mapboxgl-ctrl-geocoder button');
-    inputEl.addEventListener('change', once(() => {
+    inputEl.addEventListener('change', once(function() {
       t.ok(inputEl.value, 'value populates in input');
       t.ok(clearEl.classList.contains('active'), 'clear link is active');
       clearEl.dispatchEvent(clickEvent);
     }));
 
-    geocoder.on('geocoder.loading', once(() => {
+    geocoder.on('geocoder.loading', once(function() {
       t.ok('load event was emitted');
     }));
 
-    geocoder.on('geocoder.clear', once(() => {
+    geocoder.on('geocoder.clear', once(function() {
       t.ok('input was cleared');
     }));
 
     geocoder.query([-79, 43]);
   });
 
-  tt.test('position', t => {
+  tt.test('position', function(t) {
     setup({ position: 'bottom-left' });
     t.ok(map.getContainer().querySelector('.mapboxgl-ctrl-bottom-left .mapboxgl-ctrl-geocoder'));
     t.end();
   });
 
-  tt.test('container', t => {
+  tt.test('container', function(t) {
     container = document.createElement('div');
     map = new mapboxgl.Map({ container: container });
 
-    const customEl = document.createElement('div');
+    var customEl = document.createElement('div');
     customEl.id = 'custom';
     map.getContainer().appendChild(customEl);
 


### PR DESCRIPTION
If this plugin is added to a project via npm the project had to also respect
ES6 syntax by using a compiler like Babel. This is expecting too much.

Other notable changes:

- Use envify inline with the npm test command
- Use xtend module over Object.assign. Closes #10