### PR TITLE
Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["object-assign"]
+  "plugins": ["transform-object-assign"],
+  "presets": ["es2015"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,3 @@
 {
-  "stage": 0,
-  "loose": "all",
   "plugins": ["object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "uglify-js": "^2.4.24"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.12.1"
+    "mapbox-gl": "^0.13.1 || ^0.14.0"
   },
   "dependencies": {
     "lodash.debounce": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "homepage": "https://github.com/mapbox/mapbox-gl-geocoder#readme",
   "devDependencies": {
     "babel-eslint": "^4.0.10",
-    "babel-plugin-object-assign": "^1.2.1",
+    "babel-plugin-transform-object-assign": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^11.2.0",
     "budo": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "babel-eslint": "^4.0.10",
     "babel-plugin-object-assign": "^1.2.1",
-    "babelify": "^6.4.0",
+    "babelify": "^7.2.0",
     "browserify": "^11.2.0",
     "budo": "^7.0.2",
     "documentation": "^3.0.0",


### PR DESCRIPTION
Upgrades to the Babel 6 presets system. Also bumps the `mapbox-gl` peerDependencies (somewhat arbitrarily chose those of `mapbox-gl-draw`).

Tests pass locally but happy to do more work here to get it ready for primetime