### PR TITLE
v1.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
     input.addEventListener('keydown', debounce(function(e) {
       // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
       if ([9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
-      this._queryFromInput(e.target.value);
+      if (e.target.value.length) this._queryFromInput(e.target.value);
     }.bind(this)), 200);
 
     input.addEventListener('change', function() {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var EventEmitter = require('events').EventEmitter;
  * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
  * @param {string|element} options.container html element to initialize the map in (or element id as string). if no container is passed map.getcontainer() is used instead.
  * @param {Array<Array<number>>} options.proximity If set, search results closer to these coordinates will be given higher priority.
+ * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to.
  * @param {Boolean} [options.flyTo=true] If false, animating the map to a selected result is disabled.
  * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
  * @param {string} options.types a comma seperated list of types that filter results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type for available types.
@@ -37,6 +38,7 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
   options: {
     position: 'top-left',
     placeholder: 'Search',
+    zoom: 16,
     flyTo: true
   },
 
@@ -72,7 +74,10 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
             var bbox = selected.bbox;
             map.fitBounds([[bbox[0], bbox[1]],[bbox[2], bbox[3]]]);
           } else {
-            map.flyTo({ center: selected.center });
+            map.flyTo({
+              center: selected.center,
+              zoom: this.options.zoom
+            });
           }
         }
         this._input = selected;

--- a/index.js
+++ b/index.js
@@ -64,9 +64,11 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
     input.placeholder = this.options.placeholder;
 
     input.addEventListener('keydown', debounce(function(e) {
+      if (!e.target.value) return this._clearEl.classList.remove('active');
+
       // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
       if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
-      if (e.target.value.length) this._queryFromInput(e.target.value);
+      this._queryFromInput(e.target.value);
     }.bind(this)), 200);
 
     input.addEventListener('change', function() {
@@ -117,7 +119,7 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
   },
 
   _geocode: function(q, callback) {
-    this._loadingEl.classList.toggle('active', true);
+    this._loadingEl.classList.add('active');
     this.fire('loading');
 
     var options = {};
@@ -138,10 +140,15 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
       json: true
     }, function(err, res, body) {
       if (err) return this.fire('error', { error: err.message });
-      this._loadingEl.classList.toggle('active', false);
-      if (!body.features.length) this._typeahead.selected = null;
+      this._loadingEl.classList.remove('active');
+      if (body.features.length) {
+        this._clearEl.classList.add('active');
+      } else {
+        this._clearEl.classList.remove('active');
+        this._typeahead.selected = null;
+      }
+
       this._typeahead.update(body.features);
-      this._clearEl.classList.toggle('active', body.features.length);
       return callback(body.features);
     }.bind(this));
   },

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
 
     input.addEventListener('keydown', debounce(function(e) {
       // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
-      if ([9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
+      if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
       if (e.target.value.length) this._queryFromInput(e.target.value);
     }.bind(this)), 200);
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
+
 /* global mapboxgl */
+if (!mapboxgl) throw new Error('include mapboxgl before mapbox-gl-geocoder.js');
 
 var MapboxClient = require('mapbox/lib/services/geocoder');
 var Typeahead = require('suggestions');

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
     // Override the control being added to control containers
     if (this.options.container) this.options.position = false;
 
-    this._typeahead = new Typeahead(input, []);
+    this._typeahead = new Typeahead(input, [], { filter: false });
     this._typeahead.getItemValue = function(item) { return item.place_name; };
 
     return el;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "lodash.debounce": "^3.1.1",
     "mapbox": "^0.12.0",
-    "suggestions": "^1.2.0",
+    "suggestions": "^1.3.0",
     "xtend": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "lodash.debounce": "^3.1.1",
-    "mapbox": "^0.12.0",
+    "request": "^2.72.0",
     "suggestions": "^1.3.0",
     "xtend": "^4.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "tape": "^4.2.0",
     "uglify-js": "^2.4.24"
   },
-  "peerDependencies": {
-    "mapbox-gl": "^0.13.1 || ^0.14.0 || ^0.15.0"
-  },
   "dependencies": {
     "lodash.debounce": "^3.1.1",
     "mapbox": "^0.12.0",

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -53,6 +53,17 @@ test('geocoder', function(tt) {
     }));
   });
 
+  tt.test('options:zoom', function(t) {
+    t.plan(1);
+    setup({ zoom: 12 });
+    geocoder.query('1714 14th St NW');
+    geocoder.on('result', once(function() {
+      map.once(map.on('moveend', function() {
+        t.equals(map.getZoom(), 12, 'Custom zoom is supported');
+      }));
+    }));
+  });
+
   tt.test('fire', function(t) {
     t.plan(2);
     setup();


### PR DESCRIPTION
- [performance] Swap mapbox-sdk-js out for request
- [feature] Pass a custom `zoom` option
- [bug] Dont call query function when input value is empty
- [bug] Disable geocoder on `metaKey` keydown event
- [bug] Drop the poorly supported toggle method
- [bug] Return error if `mapboxgl` is not included.
- [bug] Bump suggestions pkg to support a no filter option