### PR TITLE
adjust for mapzen search API

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -2,7 +2,7 @@
 /* global mapboxgl */
 
 require('../');
-mapboxgl.accessToken = window.localStorage.getItem('MapboxAccessToken');
+mapboxgl.accessToken = "pk.eyJ1IjoiZGFuc3dpY2siLCJhIjoieUZiWmwtVSJ9.0cPQywdbPVmvHiHJ6NwdXA";
 
 var map = new mapboxgl.Map({
   container: 'map',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lodash.debounce": "^3.1.1",
     "request": "^2.72.0",
     "suggestions": "^1.3.0",
-    "xtend": "^4.0.1"
+    "xtend": "^4.0.1",
+    "jquery": "^2.2.0"
   }
 }


### PR DESCRIPTION
Makes a few changes to use the [mapzen search](https://mapzen.com/documentation/search/) API instead of the [Mapbox Geocoding API](https://www.mapbox.com/api-documentation/#geocoding). 