### PR TITLE
Replace request with isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "uglify-js": "^2.6.4"
   },
   "dependencies": {
+    "es6-promise": "^3.2.1",
+    "isomorphic-fetch": "^2.2.1",
     "lodash.debounce": "^4.0.6",
-    "request": "^2.72.0",
     "suggestions": "^1.3.0",
     "xtend": "^4.0.1"
   }


### PR DESCRIPTION
This change started it's life as a bughunt.

While debugging the error `A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin'
header when the credentials flag is true` I came across
request/request#986. markbahnman's comment in that issue resolves that
particular error which then revealed another request related error
`TypeError: self.req.abort is not a function`.

Given the characterization of request as "a Node.js library,
used server-side" and the errors, it seemed an opportune moment to
explore removing request and exploring another library.

This commit does exactly that, removing `request` and replacing it with
`isomorphic-fetch`.

One open question with this approach is that the old code would cancel
this.request if it existed. Cancelling a fetch is under discussion in
whatwg/fetch#27 is as yet unresolved.

Apart from that, the tests all pass, the lint is clean, and it's working in my project so I thought I would send a PR for your consideration.
If there are other changes/improvements that need to be made, let me know.