### PR TITLE
Allows module to be imported/required

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
-/* global mapboxgl */
-if (typeof mapboxgl === 'undefined') throw new Error('include mapboxgl before mapbox-gl-geocoder.js');
+var mapboxgl
+if (typeof window === 'undefined' || typeof window.mapbox === 'undefined') {
+  mapboxgl = require('mapbox-gl');
+} else {
+  mapboxgl = window.mapboxgl;
+}
 
 var Typeahead = require('suggestions');
 var debounce = require('lodash.debounce');


### PR DESCRIPTION
At present, if the `mapbox-gl` module has been imported/required rather than added to global scope, an error will be thrown when you try to import/require this module.  This makes it impossible to use with something like [react-map-gl](https://github.com/uber/react-map-gl).

This PR removes the check and replaces it with code which either assigns either the global `mapboxgl` instance, or a required version of the module, to the local `mapboxgl`, allowing it to be used in either case.