### PR TITLE
Add automatic s3 deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,5 +25,4 @@ Lastly, run the test command from the console:
 - `git tag -a vX.X.X -m 'vX.X.X'`
 - `git push --tags`
 - `npm publish`
-- Deploy packaged plugin in [mapbox-gl-plugins](https://github.com/mapbox/mapbox-gl-plugins)
-- Update version links in documentation
+- Update version number in GL JS examples ([one](https://github.com/mapbox/mapbox-gl-js/blob/mb-pages/docs/_posts/examples/3400-01-12-mapbox-gl-geocoder.html), [two](https://github.com/mapbox/mapbox-gl-js/blob/mb-pages/docs/_posts/examples/3400-01-16-point-from-geocoder-result.html))

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,11 @@
+test:
+  override:
+    - npm run lint
 machine:
   node:
     version: 4
+deployment:
+  release:
+    tag: /v[0-9]+\.[0-9]+\.[0-9]+(\-dev)?/
+    commands:
+      - aws s3 cp --recursive --acl public-read dist s3://mapbox-gl-js/plugins/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG


### PR DESCRIPTION
This PR enables automatic s3 deployment which publishes to s3 via CircleCI whenever a release tag is pushed to GitHub. This frees us from having to do deployment manually within the GL JS repository.

Related to mapbox/mapbox-gl-js#4305