### PR TITLE
add query parameter to loading event

### DIFF
--- a/API.md
+++ b/API.md
@@ -48,7 +48,7 @@ Subscribe to events that happen within the plugin.
 **Parameters**
 
 -   `type` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
-    -   **loading** `Emitted when the geocoder is looking up a query`
+    -   **loading** `{ query } Emitted when the geocoder is looking up a query`
     -   **results** `{ results } Fired when the geocoder returns a response`
     -   **result** `{ result } Fired when input is set`
     -   **error** \`{ error } Error as string

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ MapboxGeocoder.prototype = {
 
   _geocode: function(searchInput) {
     this._loadingEl.style.display = 'block';
-    this._eventEmitter.emit('loading');
+    this._eventEmitter.emit('loading', { query: searchInput });
     var request = this.mapboxClient.geocodeForward(searchInput, this.options);
 
     request.then(function (response) {
@@ -198,7 +198,7 @@ MapboxGeocoder.prototype = {
    * @param {String} type name of event. Available events and the data passed into their respective event objects are:
    *
    * - __clear__ `Emitted when the input is cleared`
-   * - __loading__ `Emitted when the geocoder is looking up a query`
+   * - __loading__ `{ query } Emitted when the geocoder is looking up a query`
    * - __results__ `{ results } Fired when the geocoder returns a response`
    * - __result__ `{ result } Fired when input is set`
    * - __error__ `{ error } Error as string

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -30,10 +30,11 @@ test('Geocoder#inputControl', function(tt) {
     var inputEl = container.querySelector('.mapboxgl-ctrl-geocoder input');
     var clearEl = container.querySelector('.mapboxgl-ctrl-geocoder button');
 
-    geocoder.query('-79,43');
+    t.plan(6);
 
-    geocoder.on('loading', once(function() {
+    geocoder.on('loading', once(function(e) {
       t.pass('load event was emitted');
+      t.equals(e.query, '-79,43', 'loading event passes query parameter');
     }));
 
     geocoder.on('result', once(function() {
@@ -52,6 +53,7 @@ test('Geocoder#inputControl', function(tt) {
       t.end();
     }));
 
+    geocoder.query('-79,43');
   });
 
   tt.test('placeholder', function(t) {


### PR DESCRIPTION
I have a case where I want to know the query parameter in the loading event. It is possible to look up the search element value instead but due to timings it might not always be exactly the query passed to the geocoder.

This also contains a fix where the test case `t.pass('load event was emitted');` wasn't being checked since the query was being run before the loading event could be bound.