### PR TITLE
Add limit and minLength options. Avoid unnecessary Geocode calls after 1 character. Fixes #97 #98

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,6 +23,8 @@ A geocoder component using Mapbox Geocoding API
         for available types.
     -   `options.country` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** a comma separated list of country codes to
         limit results to specified country or countries.
+    -   `options.minLength` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Minimum number of characters to enter before results are shown. (optional, default `2`)
+    -   `options.limit` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Maximum number of results to show. (optional, default `5`)
 
 **Examples**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,8 @@ var MapboxClient = require('mapbox/lib/services/geocoding');
  * for available types.
  * @param {string} [options.country] a comma separated list of country codes to
  * limit results to specified country or countries.
+ * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
+ * @param {Number} [options.limit=5] Maximum number of results to show.
  * @example
  * var geocoder = new MapboxGeocoder();
  * map.addControl(geocoder);
@@ -43,7 +45,9 @@ MapboxGeocoder.prototype = {
   options: {
     placeholder: 'Search',
     zoom: 16,
-    flyTo: true
+    flyTo: true,
+    minLength: 2,
+    limit: 5
   },
 
   onAdd: function(map) {
@@ -84,7 +88,11 @@ MapboxGeocoder.prototype = {
     el.appendChild(this._inputEl);
     el.appendChild(actions);
 
-    this._typeahead = new Typeahead(this._inputEl, [], { filter: false });
+    this._typeahead = new Typeahead(this._inputEl, [], {
+        filter: false,
+        minLength: this.options.minLength,
+        limit: this.options.limit
+    });
     this._typeahead.getItemValue = function(item) { return item.place_name; };
 
     return el;
@@ -103,7 +111,10 @@ MapboxGeocoder.prototype = {
 
     // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
     if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
-    this._geocode(e.target.value);
+
+    if (e.target.value.length >= this.options.minLength) {
+        this._geocode(e.target.value);
+    }
   }, 200),
 
   _onChange: function() {

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -77,6 +77,19 @@ test('geocoder', function(tt) {
     }));
   });
 
+  tt.test('options.limit', function(t) {
+    t.plan(1);
+    setup({
+      flyTo: false,
+      limit: 6
+    });
+
+    geocoder.query('London');
+    geocoder.on('results', once(function(e) {
+      t.equal(e.features.length, 6, 'Results limit applied');
+    }));
+  });
+
   tt.test('options:zoom', function(t) {
     t.plan(1);
     setup({ zoom: 12 });


### PR DESCRIPTION
the `geocode` method called will still apply even when length is < minLength. I think that's the intention of geocode. The minLength only applies to users typing in the input.

Addresses #97 and #98.