### PR TITLE
Add Geocoding API params to JSDoc to be included in API.md. Fixes #96

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,6 +11,18 @@ A geocoder component using Mapbox Geocoding API
     -   `options.zoom` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** On geocoded result what zoom level should the map animate to. (optional, default `16`)
     -   `options.flyTo` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** If false, animating the map to a selected result is disabled. (optional, default `true`)
     -   `options.placeholder` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Override the default placeholder attribute value. (optional, default `"Search"`)
+    -   `options.proximity` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** a proximity argument: this is
+        a geographical point given as an object with latitude and longitude
+        properties. Search results closer to this point will be given
+        higher priority.
+    -   `options.bbox` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)]** a bounding box argument: this is
+        a bounding box given as an array in the format [minX, minY, maxX, maxY].
+        Search results will be limited to the bounding box.
+    -   `options.types` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** a comma seperated list of types that filter
+        results to match those specified. See <https://www.mapbox.com/developers/api/geocoding/#filter-type>
+        for available types.
+    -   `options.country` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** a comma separated list of country codes to
+        limit results to specified country or countries.
 
 **Examples**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,18 @@ var MapboxClient = require('mapbox/lib/services/geocoding');
  * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to.
  * @param {Boolean} [options.flyTo=true] If false, animating the map to a selected result is disabled.
  * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
+ * @param {Object} [options.proximity] a proximity argument: this is
+ * a geographical point given as an object with latitude and longitude
+ * properties. Search results closer to this point will be given
+ * higher priority.
+ * @param {Array} [options.bbox] a bounding box argument: this is
+ * a bounding box given as an array in the format [minX, minY, maxX, maxY].
+ * Search results will be limited to the bounding box.
+ * @param {string} [options.types] a comma seperated list of types that filter
+ * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
+ * for available types.
+ * @param {string} [options.country] a comma separated list of country codes to
+ * limit results to specified country or countries.
  * @example
  * var geocoder = new MapboxGeocoder();
  * map.addControl(geocoder);


### PR DESCRIPTION
copied from https://github.com/mapbox/mapbox-sdk-js/blob/master/lib/services/geocoding.js. I don't like duplicating this twice, but I'm not sure of how else to get the params into the API.md