### PR TITLE
Clarify options.zoom only applies when a Geocoding API response doesn't contain a bbox.

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ A geocoder component using Mapbox Geocoding API
 
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `options.accessToken` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Required. (optional, default `null`)
-    -   `options.zoom` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** On geocoded result what zoom level should the map animate to. (optional, default `16`)
+    -   `options.zoom` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
     -   `options.flyTo` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** If false, animating the map to a selected result is disabled. (optional, default `true`)
     -   `options.placeholder` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Override the default placeholder attribute value. (optional, default `"Search"`)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ var MapboxClient = require('mapbox/lib/services/geocoding');
  *
  * @param {Object} options
  * @param {String} [options.accessToken=null] Required.
- * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to.
+ * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
  * @param {Boolean} [options.flyTo=true] If false, animating the map to a selected result is disabled.
  * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
  * @example


### PR DESCRIPTION
See #94 for background.