### PR TITLE
Fix local testing/develop URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Developing
 
-    npm install & npm start & open http://localhost:9966/example/
+    npm install & npm start & open http://localhost:9966/
 
 You'll need a [Mapbox access token](https://www.mapbox.com/help/create-api-access-token/) stored in localstorage. Set it via
 


### PR DESCRIPTION
The `npm start` script serves the debug page from `/`. `/examples/` returns 404.