### PR TITLE
use a different background color for hover and active

### DIFF
--- a/lib/mapbox-gl-geocoder.css
+++ b/lib/mapbox-gl-geocoder.css
@@ -97,10 +97,15 @@
     color:#404040;
     }
     .mapboxgl-ctrl-geocoder ul > li:last-child > a { border-bottom:none; }
-    .mapboxgl-ctrl-geocoder ul > li.active > a,
     .mapboxgl-ctrl-geocoder ul > li > a:hover {
       color:#202020;
-      background-color:#eee;
+      background-color:#f3f3f3;
+      text-decoration:none;
+      cursor:pointer;
+      }
+    .mapboxgl-ctrl-geocoder ul > li.active > a {
+      color:#202020;
+      background-color:#e3e3e3;
       text-decoration:none;
       cursor:pointer;
       }


### PR DESCRIPTION
Similar to the behaviour of http://leaverou.github.io/awesomplete/, I think it's a better UX to have a different shade for the `active` and `hover` list items.

In the current behaviour if you have used the keyboard to change the active item but then start hovering a different item being the same shade can be confusing.