### PR TITLE
Fix "TypeError: Attempted to assign to readonly property" in Safari 9 on `npm start`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,9 @@
     "node": true,
     "browser": true
   },
-  "extends": "eslint:recommended"
+  "extends": "eslint:recommended",
+  "rules": {
+    "indent": ["error", 2],
+    "no-console": "warn"
+  }
 }

--- a/example/index.js
+++ b/example/index.js
@@ -10,7 +10,11 @@ insertCss(fs.readFileSync('./node_modules/mapbox-gl/dist/mapbox-gl.css', 'utf8')
 var MapboxGeocoder = require('../');
 
 var mapDiv = document.body.appendChild(document.createElement('div'));
-mapDiv.style = 'position:absolute;top:0;right:0;left:0;bottom:0;';
+mapDiv.style.position = 'absolute';
+mapDiv.style.top = 0;
+mapDiv.style.right = 0;
+mapDiv.style.left = 0;
+mapDiv.style.bottom = 0;
 
 var map = new mapboxgl.Map({
   container: mapDiv,
@@ -29,7 +33,10 @@ var button = document.createElement('button');
 button.textContent = 'click me';
 
 var removeBtn = document.body.appendChild(document.createElement('button'));
-removeBtn.style = 'position:absolute;z-index:10;top:10px;left:10px;';
+removeBtn.style.position = 'absolute';
+removeBtn.style.zIndex = 10;
+removeBtn.style.top = '10px';
+removeBtn.style.left = '10px';
 removeBtn.textContent = 'Remove geocoder control';
 
 map.getContainer().querySelector('.mapboxgl-ctrl-bottom-left').appendChild(button);

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,9 +90,9 @@ MapboxGeocoder.prototype = {
     el.appendChild(actions);
 
     this._typeahead = new Typeahead(this._inputEl, [], {
-        filter: false,
-        minLength: this.options.minLength,
-        limit: this.options.limit
+      filter: false,
+      minLength: this.options.minLength,
+      limit: this.options.limit
     });
     this._typeahead.getItemValue = function(item) { return item.place_name; };
 
@@ -114,7 +114,7 @@ MapboxGeocoder.prototype = {
     if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
 
     if (e.target.value.length >= this.options.minLength) {
-        this._geocode(e.target.value);
+      this._geocode(e.target.value);
     }
   }, 200),
 

--- a/test/index.js
+++ b/test/index.js
@@ -7,9 +7,9 @@ require('./test.geocoder');
 require('./test.ui');
 
 // close the smokestack window once tests are complete
-test('shutdown', (t) => {
+test('shutdown', function(t) {
   t.end();
-  setTimeout(() => {
+  setTimeout(function() {
     window.close();
-  });
+  }, 0);
 });


### PR DESCRIPTION
Safari 9 fails to open localhost:9966 after `npm start`, console says 
> TypeError: Attempted to assign to readonly property.

about example/index.js style assignments. This fixes it + removes some static code analysis warnings in WebStorm. :)