### PR TITLE
v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v2.1.2
+
+- Bump suggestions version which includes:
+   - [bug] prevent form submission on selecting a result from the list [#15](https://github.com/tristen/suggestions/pull/15)
+   - [bug] ensure paste events open list [#17](https://github.com/tristen/suggestions/pull/17)
+   - [bug] use mouseup rather than mousedown for list selection [#18](https://github.com/tristen/suggestions/pull/18)
+
 ### v2.1.1
 
 - Adds option for language parameter [#126](https://github.com/mapbox/mapbox-gl-geocoder/pull/126). 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "scripts": {
@@ -47,7 +47,7 @@
   "dependencies": {
     "lodash.debounce": "^4.0.6",
     "mapbox": "1.0.0-beta9",
-    "suggestions": "^1.3.1",
+    "suggestions": "^1.3.2",
     "xtend": "^4.0.1"
   }
 }


### PR DESCRIPTION
Doing a new release which explicitly pulls in suggestions 1.3.2, see also https://github.com/mapbox/mapbox-gl-geocoder/issues/34#issuecomment-332175835

Closes #34
Closes #68
Allows a workaround for #118.

part of this PR:
- [x] npm run prepublish && npm run docs
- [x] Update the version key in package.json
- [x] Outline changes in CHANGELOG.md
- [x] Commit and push

after merged:
- [ ] git tag -a vX.X.X -m 'vX.X.X'
- [ ] git push --tags
- [ ] npm publish
- [ ] Update version number in GL JS examples (one, two)