### PR TITLE
add filter option

### DIFF
--- a/example/filter.js
+++ b/example/filter.js
@@ -1,0 +1,69 @@
+'use strict';
+var mapboxgl = require('mapbox-gl');
+var insertCss = require('insert-css');
+var fs = require('fs');
+mapboxgl.accessToken = window.localStorage.getItem('MapboxAccessToken');
+
+insertCss(fs.readFileSync('./lib/mapbox-gl-geocoder.css', 'utf8'));
+insertCss(fs.readFileSync('./node_modules/mapbox-gl/dist/mapbox-gl.css', 'utf8'));
+
+var MapboxGeocoder = require('../');
+
+var mapDiv = document.body.appendChild(document.createElement('div'));
+mapDiv.style.position = 'absolute';
+mapDiv.style.top = 0;
+mapDiv.style.right = 0;
+mapDiv.style.left = 0;
+mapDiv.style.bottom = 0;
+
+var map = new mapboxgl.Map({
+  container: mapDiv,
+  style: 'mapbox://styles/mapbox/streets-v9',
+  center: [-79.4512, 43.6568],
+  zoom: 13
+});
+
+var geocoder = new MapboxGeocoder({
+  accessToken: window.localStorage.getItem('MapboxAccessToken'),
+  country: 'au',
+  filter: function (item) {
+    // returns true if item contains New South Wales region
+    return item.context.map((i) => {
+        return (i.id.startsWith('region') && i.text == "New South Wales")
+    }).reduce((acc, cur) => {
+        return acc || cur;
+    });
+  }
+});
+
+window.geocoder = geocoder;
+
+var button = document.createElement('button');
+button.textContent = 'click me';
+
+var removeBtn = document.body.appendChild(document.createElement('button'));
+removeBtn.style.position = 'absolute';
+removeBtn.style.zIndex = 10;
+removeBtn.style.top = '10px';
+removeBtn.style.left = '10px';
+removeBtn.textContent = 'Remove geocoder control';
+
+map.getContainer().querySelector('.mapboxgl-ctrl-bottom-left').appendChild(button);
+map.addControl(geocoder);
+
+map.on('load', function() {
+  button.addEventListener('click', function() {
+    geocoder.query('Montreal Quebec');
+  });
+  removeBtn.addEventListener('click', function() {
+    map.removeControl(geocoder);
+  })
+});
+
+geocoder.on('results', function(e) {
+  console.log('results: ', e.features);
+});
+
+geocoder.on('error', function(e) {
+  console.log('Error is', e.error);
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ var MapboxClient = require('mapbox/lib/services/geocoding');
  * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
+ * @param {Function} [options.filter] A callback function to filter out results from the Geocoding API response before they are included in the suggestions list.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -155,7 +156,12 @@ MapboxGeocoder.prototype = {
 
     request.then(function (response) {
       this._loadingEl.style.display = 'none';
+
       var res = response.entity;
+      if (this.options.filter && response.entity.features.length) {
+        res.features = response.entity.features.filter(this.options.filter);
+      }
+
       if (res.features.length) {
         this._clearEl.style.display = 'block';
       } else {


### PR DESCRIPTION
Add a filter option accepting a callback function to filter out results from the Geocoding API response before they are included in the suggestions list.

This helps workaround the fact that the Geocoding API only has board brush filtering (country, bbox, types), a client side filter lets you use much finer brush filtering, for example limiting search results to one administrative region or polygon.

I'd probably remove example/filter.js before merging this since it mostly duplicates the main example, but just leaving it here for now.

This PR is an alternate solution to address #132