### PR TITLE
check for shadowRoot retargeting for keydown event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,15 +107,17 @@ MapboxGeocoder.prototype = {
   },
 
   _onKeyDown: debounce(function(e) {
-    if (!e.target.value) {
+    // if target has shadowRoot, then get the actual active element inside the shadowRoot
+    var target = e.target.shadowRoot ? e.target.shadowRoot.activeElement : e.target;
+    if (!target.value) {
       return this._clearEl.style.display = 'none';
     }
 
     // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
     if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
 
-    if (e.target.value.length >= this.options.minLength) {
-      this._geocode(e.target.value);
+    if (target.value.length >= this.options.minLength) {
+      this._geocode(target.value);
     }
   }, 200),
 


### PR DESCRIPTION
**Background**
I created a Polymer webcomponent [`mapbox-gl`](https://www.webcomponents.org/element/PolymerVis/mapbox-gl) for mapbox-gl-js. I have several other supporting components which can be used together with `mapbox-gl`. One of which is `mapbox-gl-geocoder`. 

**Issue**
The parent node for the map are inside the shadowRoot, hence the `event.target` for the `keydown` event is [retargeted](https://www.w3.org/TR/shadow-dom/#retarget) to the `mapbox-gl` element instead of the input element. Hence, the query will never fire as value will always be null.
  
**Workaround**
Currently, I am monkey-patching `_onKeyDown` to correctly pass in the input element. 

**Pull request**
This pull request adds a check for the existence of the shadowRoot, and extract the value from the correct target ([activeElement](https://www.w3.org/TR/shadow-dom/#active-element) of the shadowRoot). 

*PS: It would be nice if u can notify me if this pull request is accepted and released, so that I can remove my monkey-patching for my next release.*

