### PR TITLE
add local geocoder option

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,6 +37,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.limit` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of results to show. (optional, default `5`)
     -   `options.language` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
     -   `options.filter` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+    -   `options.localGeocoder` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
 
 **Examples**
 

--- a/example/index.js
+++ b/example/index.js
@@ -23,8 +23,51 @@ var map = new mapboxgl.Map({
   zoom: 13
 });
 
+var coordinatesGeocoder = function (query) {
+    var matches = query.match(/^[ ]*(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/);
+    if (!matches) {
+        return null;
+    }
+    function coordinateFeature(lng, lat) {
+        var lng = Number(lng);
+        var lat = Number(lat);
+        return {
+            center: [lng, lat],
+            geometry: {
+                type: "Point",
+                coordinates: [lng, lat]
+            },
+            place_name: 'Lat: ' + lat + ', Lng: ' + lng,
+            place_type: ['coordinate'],
+            properties: {},
+            type: 'Feature'
+        };
+    }
+    var coord1 = matches[1];
+    var coord2 = matches[2];
+    var geocodes = [];
+    if (coord1 < -90 || coord1 > 90) {
+        // must be lng, lat
+        geocodes.push(coordinateFeature(coord1, coord2));
+    }
+    if (coord2 < -90 || coord2 > 90) {
+        // must be lat, lng
+        geocodes.push(coordinateFeature(coord2, coord1));
+    }
+    if (geocodes.length == 0) {
+        // else could be either
+        geocodes.push(coordinateFeature(coord1, coord2));
+        geocodes.push(coordinateFeature(coord2, coord1));
+    }
+    console.log(geocodes);
+    return geocodes;
+};
+
 var geocoder = new MapboxGeocoder({
-  accessToken: window.localStorage.getItem('MapboxAccessToken')
+  accessToken: window.localStorage.getItem('MapboxAccessToken'),
+  localGeocoder: function (query) {
+      return coordinatesGeocoder(query);
+  }
 });
 
 window.geocoder = geocoder;

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ var MapboxClient = require('mapbox/lib/services/geocoding');
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
  * @param {Function} [options.filter] A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+ * @param {Function} [options.localGeocoder] A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -156,12 +157,25 @@ MapboxGeocoder.prototype = {
     this._eventEmitter.emit('loading', { query: searchInput });
     var request = this.mapboxClient.geocodeForward(searchInput, this.options);
 
+    var localGeocoderRes = [];
+    if (this.options.localGeocoder) {
+      localGeocoderRes = this.options.localGeocoder(searchInput);
+      if (!localGeocoderRes) {
+        localGeocoderRes = [];
+      }
+    }
+
     request.then(function (response) {
       this._loadingEl.style.display = 'none';
 
       var res = response.entity;
-      if (this.options.filter && response.entity.features.length) {
-        res.features = response.entity.features.filter(this.options.filter);
+
+      // supplement Mapbox Geocoding API results with locally populated results
+      res.features = res.features ? localGeocoderRes.concat(res.features) : localGeocoderRes;
+
+      // apply results filter if provided
+      if (this.options.filter && res.features.length) {
+        res.features = res.features.filter(this.options.filter);
       }
 
       if (res.features.length) {
@@ -177,6 +191,18 @@ MapboxGeocoder.prototype = {
 
     request.catch(function (err) {
       this._loadingEl.style.display = 'none';
+
+      // in the event of an error in the Mapbox Geocoding API still display results from the localGeocoder
+      if (localGeocoderRes.length) {
+        this._clearEl.style.display = 'block';
+      } else {
+        this._clearEl.style.display = 'none';
+        this._typeahead.selected = null;
+      }
+
+      this._eventEmitter.emit('results', { features: localGeocoderRes });
+      this._typeahead.update(localGeocoderRes);
+
       this._eventEmitter.emit('error', { error: err });
     }.bind(this));
 

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -101,6 +101,32 @@ test('geocoder', function(tt) {
     }));
   });
 
+  tt.test('options.localGeocoder', function(t) {
+    t.plan(3);
+    setup({
+      flyTo: false,
+      limit: 6,
+      localGeocoder: function(q) {
+          return q;
+      }
+    });
+
+    geocoder.query('-30,150');
+    geocoder.once('results', once(function(e) {
+      t.equal(e.features.length, 1, 'Local geocoder used');
+
+      geocoder.query('London');
+      geocoder.once('results', once(function(e) {
+        t.equal(e.features.length, 7, 'Local geocoder suppliment remote response');
+
+        geocoder.query('London');
+        geocoder.once('results', once(function(e) {
+          t.equal(e.features[0], 'London', 'Local geocoder results above remote response');
+        }));
+      }));
+    }));
+  });
+
   tt.test('country bbox', function(t) {
     t.plan(1);
     setup({});


### PR DESCRIPTION
The idea of this PR is to allow the app developer to supplier their own local geocoder function to supplement results from the external api. Two main use cases are:

- accepting coordinates as input to the geocoder (I've included this in the example)
- providing results from a local GeoJSON dataset

This PR stops short of providing this asynchronously, so you can't call a 3rd party remote API to supplement results. That could be added in a future PR.

replaces #123, helps to support #121 

I'm happy with this now, any feedback welcome.