### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v2.2.0
+
+- Add filter option [#133](https://github.com/mapbox/mapbox-gl-geocoder/pull/133)
+- Add localGeocoder option [#136](https://github.com/mapbox/mapbox-gl-geocoder/pull/136)
+- Check for shadowRoot retargeting for keypressdown event [#134](https://github.com/mapbox/mapbox-gl-geocoder/pull/134)
+
 ### v2.1.2
 
 - Bump suggestions version which includes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "style": "lib/mapbox-gl-geocoder.css",


### PR DESCRIPTION
new release, unlocks https://github.com/mapbox/mapbox-gl-js/pull/5915

part of this PR:

- [x] npm run prepublish && npm run docs
- [x] Update the version key in package.json
- [x] Outline changes in CHANGELOG.md
- [x] Commit and push

after merged:

- [ ] git tag v2.2.0
- [ ] git push upstream tag v2.2.0
- [ ] npm publish
- [ ] Update version number in GL JS examples: will be done in https://github.com/mapbox/mapbox-gl-js/pull/5915