### PR TITLE
Bugfix: Syntax error: Link to example was broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [API.md](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md) fo
 #### Examples
 
  - [Add a geocoder to Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder/)
- - [Place the geocoder input outside the map](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-outsite-the-map/)
+ - [Place the geocoder input outside the map](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-outside-the-map/)
  - [Limit geocoder results to a named region](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-limit-region/)
  - [Supplement geocoding search results from another data source](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-local-geocoder)
  - [Bias geocoder results around the map view](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-proximity-bias)


### PR DESCRIPTION
Link to example 'Place the geocoder input outside the map' was broken. In the href attribute, it read 'outsite' instead of 'outside'.