### PR TITLE
always fit to bbox if exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,9 +128,7 @@ MapboxGeocoder.prototype = {
     var selected = this._typeahead.selected;
     if (selected) {
       if (this.options.flyTo) {
-        if (!exceptions[selected.id] &&
-            (selected.bbox && selected.context && selected.context.length <= 3 ||
-            selected.bbox && !selected.context)) {
+        if (!exceptions[selected.id] && selected.bbox) {
           var bbox = selected.bbox;
           this._map.fitBounds([[bbox[0], bbox[1]],[bbox[2], bbox[3]]]);
         } else if (exceptions[selected.id]) {


### PR DESCRIPTION
@tristen this undos #30 which was done to address #23, however I can't understand why it's needed?

As a counter example see:
![selection_849](https://user-images.githubusercontent.com/117278/37636699-ac1073ee-2c57-11e8-8c36-2c7350b45c06.png)

```json
  {
      "id": "locality.10733803972294880",
      "type": "Feature",
      "place_type": [
        "locality"
      ],
      "relevance": 1,
      "properties": {
        "wikidata": "Q2733536"
      },
      "text": "Cronulla",
      "place_name": "Cronulla, Sydney, New South Wales, Australia",
      "bbox": [
        151.14313749261,
        -34.07764546406,
        151.16526158076,
        -34.03901257567
      ],
      "center": [
        151.152,
        -34.0574
      ],
      "geometry": {
        "type": "Point",
        "coordinates": [
          151.152,
          -34.0574
        ]
      },
      "context": [
        {
          "id": "postcode.8858496765414730",
          "text": "2230"
        },
        {
          "id": "place.4960085988742460",
          "wikidata": "Q3130",
          "text": "Sydney"
        },
        {
          "id": "region.3703",
          "short_code": "AU-NSW",
          "wikidata": "Q3224",
          "text": "New South Wales"
        },
        {
          "id": "country.3104",
          "short_code": "au",
          "wikidata": "Q408",
          "text": "Australia"
        }
      ]
    }
```

Currently it won't fit to the bbox since it has 4 context items, instead choosing to zoom in to zoom 16 (default `options.zoom`) which is far greater than if it fit to the bbox.

The original issue was "1 Broadway, Manhattan, New York, New York 10004, United States" which doesn't return a bbox so would still be fine even with this PR.