### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v2.3.0
+
+- Add trackProximity option [#151](https://github.com/mapbox/mapbox-gl-geocoder/pull/151)
+- Always fit to bbox if exists in Geocoding API response [#148](https://github.com/mapbox/mapbox-gl-geocoder/pull/148)
+
 ### v2.2.0
 
 - Add filter option [#133](https://github.com/mapbox/mapbox-gl-geocoder/pull/133)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "style": "lib/mapbox-gl-geocoder.css",


### PR DESCRIPTION
@tristen or @mollymerp new release, if all good I'll merge, push the v2.3.0 tag and then get you to `npm publish`.

- [x] npm run test
- [ ] push tag
- [ ] npm publish
- [ ] Update version number in GL JS examples ([one](https://github.com/mapbox/mapbox-gl-js/blob/gh-pages/docs/pages/example/mapbox-gl-geocoder.html), [two](https://github.com/mapbox/mapbox-gl-js/blob/gh-pages/docs/pages/example/point-from-geocoder-result.html), [three](https://github.com/mapbox/mapbox-gl-js/blob/gh-pages/docs/pages/example/mapbox-gl-geocoder-outside-the-map.html), [four](https://github.com/mapbox/mapbox-gl-js/blob/gh-pages/docs/pages/example/mapbox-gl-geocoder-limit-region.html), [five](https://github.com/mapbox/mapbox-gl-js/blob/gh-pages/docs/pages/example/mapbox-gl-geocoder-local-geocoder.html), [six](https://github.com/mapbox/mapbox-gl-js/blob/gh-pages/docs/pages/example/mapbox-gl-geocoder-proximity-bias.html))