### PR TITLE
Amend the client initialization to pass through options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ MapboxGeocoder.prototype = {
 
   onAdd: function(map) {
     this._map = map;
-    this.mapboxClient = new MapboxClient(this.options.accessToken);
+    this.mapboxClient = new MapboxClient(this.options.accessToken, this.options);
     this._onChange = this._onChange.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
     this._onQueryResult = this._onQueryResult.bind(this);

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,10 @@ MapboxGeocoder.prototype = {
 
   onAdd: function(map) {
     this._map = map;
-    this.mapboxClient = new MapboxClient(this.options.accessToken, this.options);
+    this.mapboxClient = new MapboxClient(this.options.accessToken, {
+      origin: this.options.origin,
+      endpoint: this.options.endpoint,
+    });
     this._onChange = this._onChange.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
     this._onQueryResult = this._onQueryResult.bind(this);


### PR DESCRIPTION
When trying to use a custom endpoint (for example tunnelling a request through some backend) the client gets initialized without passing the `endpoint` parameter to `mapbox-gl`. This fixes this problem, also wondered if there is any gotchas I'm missing here? 

Thanks! 