### PR TITLE
Make reverse geocoding optional

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,14 +35,13 @@ A geocoder component using Mapbox Geocoding API
     -   `options.types` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a comma seperated list of types that filter
         results to match those specified. See <https://www.mapbox.com/developers/api/geocoding/#filter-type>
         for available types.
-        If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used. If no type is specified, reverse geocodes will default to 'district'.
-    -   `options.minLength` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Minimum number of characters to enter before results are shown. (optional, default `2`)
+        If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used.
     -   `options.limit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of results to show. (optional, default `5`)
     -   `options.language` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
     -   `options.filter` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
     -   `options.localGeocoder` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
     -   `options.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
-    -   `options.reverseGeocode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Enable reverse geocoding. Defaults to true. Expects coordinates to be lon, lat.
+    -   `options.reverseGeocode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
 
 **Examples**
 

--- a/API.md
+++ b/API.md
@@ -35,12 +35,14 @@ A geocoder component using Mapbox Geocoding API
     -   `options.types` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a comma seperated list of types that filter
         results to match those specified. See <https://www.mapbox.com/developers/api/geocoding/#filter-type>
         for available types.
+        If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used. If no type is specified, reverse geocodes will default to 'district'.
     -   `options.minLength` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Minimum number of characters to enter before results are shown. (optional, default `2`)
     -   `options.limit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of results to show. (optional, default `5`)
     -   `options.language` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
     -   `options.filter` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
     -   `options.localGeocoder` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
     -   `options.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
+    -   `options.reverseGeocode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Enable reverse geocoding. Defaults to true.
 
 **Examples**
 

--- a/API.md
+++ b/API.md
@@ -42,7 +42,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.filter` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
     -   `options.localGeocoder` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
     -   `options.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
-    -   `options.reverseGeocode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Enable reverse geocoding. Defaults to true.
+    -   `options.reverseGeocode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Enable reverse geocoding. Defaults to true. Expects coordinates to be lon, lat.
 
 **Examples**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -221,8 +221,8 @@ MapboxGeocoder.prototype = {
       }).reverse();
 
       // client only accepts one type for reverseGeocode, so
-      // use first config type if one, if not default to poi.landmark
-      config.types ? [config.types[0]] : ["poi.landmark"];
+      // use first config type if one, if not default to poi
+      config.types ? [config.types[0]] : ["poi"];
       config = extend(config, { query: coords, limit: 1 });
       request = geocoderService.reverseGeocode(config).send();
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,14 +31,13 @@ var geocoderService;
  * @param {string} [options.types] a comma seperated list of types that filter
  * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
  * for available types.
- * If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used. If no type is specified, reverse geocodes will default to 'district'.
- * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
+ * If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used.
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
  * @param {Function} [options.filter] A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
  * @param {Function} [options.localGeocoder] A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
  * @param {'distance'|'score'} [options.reverseMode='distance'] - Set the factors that are used to sort nearby results.
- * @param {boolean} [options.reverseGeocode] Enable reverse geocoding. Defaults to true. Expects coordinates to be lon, lat.
+ * @param {boolean} [options.reverseGeocode] Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -58,7 +57,7 @@ MapboxGeocoder.prototype = {
     flyTo: true,
     trackProximity: false,
     minLength: 2,
-    reverseGeocode: true,
+    reverseGeocode: false,
     limit: 5
   },
 
@@ -218,6 +217,7 @@ MapboxGeocoder.prototype = {
     ) {
       // parse coordinates
       var coords = searchInput.split(/[\s(,)?]+/).map(function(c) {
+        console.log(c);
         return parseFloat(c, 10);
       });
       // client only accepts one type for reverseGeocode, so

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ var geocoderService;
  * @param {Function} [options.filter] A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
  * @param {Function} [options.localGeocoder] A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
  * @param {'distance'|'score'} [options.reverseMode='distance'] - Set the factors that are used to sort nearby results.
- * @param {boolean} [options.reverseGeocode] Enable reverse geocoding. Defaults to true.
+ * @param {boolean} [options.reverseGeocode] Enable reverse geocoding. Defaults to true. Expects coordinates to be lon, lat.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -158,9 +158,6 @@ MapboxGeocoder.prototype = {
 
   _onChange: function() {
     if (this._inputEl.value) this._clearEl.style.display = 'block';
-    // if (this.options.reverseGeocode && e.which === '13') {
-    //   var selected = this._typeahead.query
-    // } else {
     var selected = this._typeahead.selected;
     if (selected) {
       if (this.options.flyTo) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,12 +31,14 @@ var geocoderService;
  * @param {string} [options.types] a comma seperated list of types that filter
  * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
  * for available types.
+ * If reverseGeocode is enabled, you must specify just one type (defaults to 'district').
  * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
  * @param {Function} [options.filter] A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
  * @param {Function} [options.localGeocoder] A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
  * @param {'distance'|'score'} [options.reverseMode='distance'] - Set the factors that are used to sort nearby results.
+ * @param {boolean} [options.reverseGeocode] Enable reverse geocoding. Defaults to true.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -56,6 +58,7 @@ MapboxGeocoder.prototype = {
     flyTo: true,
     trackProximity: false,
     minLength: 2,
+    reverseGeocode: true,
     limit: 5
   },
 
@@ -155,6 +158,9 @@ MapboxGeocoder.prototype = {
 
   _onChange: function() {
     if (this._inputEl.value) this._clearEl.style.display = 'block';
+    // if (this.options.reverseGeocode && e.which === '13') {
+    //   var selected = this._typeahead.query
+    // } else {
     var selected = this._typeahead.selected;
     if (selected) {
       if (this.options.flyTo) {
@@ -202,16 +208,18 @@ MapboxGeocoder.prototype = {
     var request;
     // check if searchInput resembles coordinates, and if it does,
     // make the request a reverseGeocode
-    if (/^(\-?\d+(\.\d+)?),\s*(\-?\d+(\.\d+)?)$/.test(searchInput)) {
+    if (this.options.reverseGeocode && /(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/.test(searchInput)) {
       // parse coordinates
       var coords = searchInput.split(',').map(function(c) {
-        return parseInt(c, 10);
+        return parseFloat(c, 10);
       });
-      // we get an error if result limit isn't 1 for reverse geocodes
-      request = geocoderService.reverseGeocode(extend(config, { query: coords, limit: 1 })).send();
+      // Use first type If no types are specified, default to type: ['district']
+      // config.types = !config.types ? ['district'] : config.types[0].split();
+      config = extend(config, { query: coords, limit: 1 });
+      request = geocoderService.reverseGeocode(config).send();
     } else {
-      config.query = searchInput;
-      request = geocoderService.forwardGeocode(extend(config, { query: searchInput })).send();
+      config = extend(config, { query: searchInput });
+      request = geocoderService.forwardGeocode(config).send();
     }
 
     var localGeocoderRes = [];
@@ -249,6 +257,7 @@ MapboxGeocoder.prototype = {
           this._typeahead.selected = null;
         }
 
+        res.config = config;
         this._eventEmitter.emit('results', res);
         this._typeahead.update(res.features);
       }.bind(this)
@@ -268,7 +277,6 @@ MapboxGeocoder.prototype = {
 
         this._eventEmitter.emit('results', { features: localGeocoderRes });
         this._typeahead.update(localGeocoderRes);
-
         this._eventEmitter.emit('error', { error: err });
       }.bind(this)
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ var geocoderService;
  * @param {string} [options.types] a comma seperated list of types that filter
  * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
  * for available types.
- * If reverseGeocode is enabled, you must specify just one type (defaults to 'district').
+ * If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used. If no type is specified, reverse geocodes will default to 'district'.
  * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
@@ -191,16 +191,23 @@ MapboxGeocoder.prototype = {
     this._eventEmitter.emit('loading', { query: searchInput });
 
     // Possible config proprerties to pass to client
-    var keys = ['bbox', 'limit', 'countries', 'types', 'language', 'reverseMode'];
+    var keys = [
+      'bbox',
+      'limit',
+      'countries',
+      'types',
+      'language',
+      'reverseMode'
+    ];
     var self = this;
     // Create config object
     var config = keys.reduce(function(config, key) {
       if (self.options[key]) {
         // countries, types, and language need to be passed in as arrays to client
         // https://github.com/mapbox/mapbox-sdk-js/blob/master/services/geocoding.js#L38-L47
-        ['countries', 'types', 'language'].indexOf(key) > -1 ?
-          config[key] = self.options[key].split(', ')
-        : config[key] = self.options[key]
+        ['countries', 'types', 'language'].indexOf(key) > -1
+          ? (config[key] = self.options[key].split(', '))
+          : (config[key] = self.options[key]);
       }
       return config;
     }, {});
@@ -208,13 +215,14 @@ MapboxGeocoder.prototype = {
     var request;
     // check if searchInput resembles coordinates, and if it does,
     // make the request a reverseGeocode
-    if (this.options.reverseGeocode && /(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/.test(searchInput)) {
+    if (
+      this.options.reverseGeocode &&
+      /(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/.test(searchInput)
+    ) {
       // parse coordinates
       var coords = searchInput.split(',').map(function(c) {
         return parseFloat(c, 10);
       });
-      // Use first type If no types are specified, default to type: ['district']
-      // config.types = !config.types ? ['district'] : config.types[0].split();
       config = extend(config, { query: coords, limit: 1 });
       request = geocoderService.reverseGeocode(config).send();
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,7 +217,7 @@ MapboxGeocoder.prototype = {
       /(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/.test(searchInput)
     ) {
       // parse coordinates
-      var coords = searchInput.split(',').map(function(c) {
+      var coords = searchInput.split(/[\s(,)?]+/).map(function(c) {
         return parseFloat(c, 10);
       });
       config = extend(config, { query: coords, limit: 1 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,6 +220,9 @@ MapboxGeocoder.prototype = {
       var coords = searchInput.split(/[\s(,)?]+/).map(function(c) {
         return parseFloat(c, 10);
       });
+      // client only accepts one type for reverseGeocode, so
+      // use first config type if one, if not default to poi.landmark
+      config.types ? [config.types[0]] : ["poi.landmark"];
       config = extend(config, { query: coords, limit: 1 });
       request = geocoderService.reverseGeocode(config).send();
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -199,7 +199,7 @@ MapboxGeocoder.prototype = {
         // countries, types, and language need to be passed in as arrays to client
         // https://github.com/mapbox/mapbox-sdk-js/blob/master/services/geocoding.js#L38-L47
         ['countries', 'types', 'language'].indexOf(key) > -1 ?
-          config[key] = [self.options[key]]
+          config[key] = self.options[key].split(', ')
         : config[key] = self.options[key]
       }
       return config;

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,9 +217,9 @@ MapboxGeocoder.prototype = {
     ) {
       // parse coordinates
       var coords = searchInput.split(/[\s(,)?]+/).map(function(c) {
-        console.log(c);
         return parseFloat(c, 10);
-      });
+      }).reverse();
+
       // client only accepts one type for reverseGeocode, so
       // use first config type if one, if not default to poi.landmark
       config.types ? [config.types[0]] : ["poi.landmark"];

--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,7 @@ MapboxGeocoder.prototype = {
         // countries, types, and language need to be passed in as arrays to client
         // https://github.com/mapbox/mapbox-sdk-js/blob/master/services/geocoding.js#L38-L47
         ['countries', 'types', 'language'].indexOf(key) > -1
-          ? (config[key] = self.options[key].split(', '))
+          ? (config[key] = self.options[key].split(/[\s,]+/))
           : (config[key] = self.options[key]);
       }
       return config;

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -114,7 +114,7 @@ test('geocoder', function(tt) {
     setup({
       reverseGeocode: true
     });
-    geocoder.query('34.5177548, -6.1933875');
+    geocoder.query('-6.1933875, 34.5177548');
     geocoder.on(
       'results',
       once(function(e) {
@@ -135,7 +135,7 @@ test('geocoder', function(tt) {
       types: 'country',
       reverseGeocode: true
     });
-    geocoder.query('-7.0926 31.791');
+    geocoder.query('31.791, -7.0926');
     geocoder.on(
       'results',
       once(function(e) {
@@ -150,7 +150,7 @@ test('geocoder', function(tt) {
   tt.test('options.reverseGeocode - false by default', function(t) {
     t.plan(2);
     setup();
-    geocoder.query('34.5177548, -6.1933875');
+    geocoder.query('-6.1933875, 34.5177548');
     geocoder.on(
       'results',
       once(function(e) {

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -151,7 +151,7 @@ test('geocoder', function(tt) {
   tt.test('parses options correctly', function(t) {
     t.plan(4);
     setup({
-      language: 'en, es, zh',
+      language: 'en,es,zh',
       types: 'district, locality, neighborhood, postcode',
       countries: 'us, mx'
     });
@@ -168,7 +168,7 @@ test('geocoder', function(tt) {
         t.deepEquals(
           e.config.language,
           languages,
-          'converts language options to array'
+          'converts language options with no spaces to array'
         );
         t.deepEquals(e.config.types, types, 'converts types options to array');
         t.deepEquals(

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -109,6 +109,63 @@ test('geocoder', function(tt) {
     );
   });
 
+  tt.test('options.reverseGeocode - true by default', function(t) {
+    t.plan(3);
+    setup();
+    geocoder.query('34.5177548, -6.1933875');
+    geocoder.on(
+      'results',
+      once(function(e) {
+        t.equal(e.features.length, 1, 'One result returned');
+        t.equal(e.features[0].place_name, 'Singida, Tanzania', 'returns expected result');
+        t.equal(e.config.limit, 1, 'sets limit to 1 for reverse geocodes');
+      })
+    );
+  });
+
+  tt.test('options.reverseGeocode - false', function(t) {
+    t.plan(2);
+    setup({
+      reverseGeocode: false
+    });
+
+    geocoder.query('34.5177548, -6.1933875');
+    geocoder.on(
+      'results',
+      once(function(e) {
+        t.equal(e.features.length, 0, 'No results returned');
+      })
+    );
+    geocoder.on('error',
+    once(function(e) {
+      t.equal(e.error.statusCode, 422, 'should error')
+    }))
+  });
+
+  tt.test('parses options correctly', function(t) {
+    t.plan(4);
+    setup({
+      language: 'en, es, zh',
+      types: 'district, locality, neighborhood, postcode',
+      countries: 'us, mx'
+    });
+
+    var languages = ['en', 'es', 'zh'];
+    var types = ['district', 'locality', 'neighborhood', 'postcode'];
+    var countries = ['us', 'mx'];
+
+    geocoder.query('Hartford');
+    geocoder.on(
+      'results',
+      once(function(e) {
+        t.equal(e.features.length, 5, 'Five results returned');
+        t.deepEquals(e.config.language, languages, 'converts language options to array');
+        t.deepEquals(e.config.types, types, 'converts types options to array');
+        t.deepEquals(e.config.countries, countries, 'converts countries options to array')
+      })
+    );
+  });
+
   tt.test('options.limit', function(t) {
     t.plan(1);
     setup({

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -109,9 +109,11 @@ test('geocoder', function(tt) {
     );
   });
 
-  tt.test('options.reverseGeocode - true by default', function(t) {
+  tt.test('options.reverseGeocode - true', function(t) {
     t.plan(3);
-    setup();
+    setup({
+      reverseGeocode: true
+    });
     geocoder.query('34.5177548, -6.1933875');
     geocoder.on(
       'results',
@@ -127,10 +129,11 @@ test('geocoder', function(tt) {
     );
   });
 
-  tt.test('options.reverseGeocode - interprets coordinates correctly', function(t) {
+  tt.test('options.reverseGeocode - interprets coordinates & options correctly', function(t) {
     t.plan(3);
     setup({
-      types: 'country'
+      types: 'country',
+      reverseGeocode: true
     });
     geocoder.query('-7.0926 31.791');
     geocoder.on(
@@ -144,11 +147,9 @@ test('geocoder', function(tt) {
     );
   });
 
-  tt.test('options.reverseGeocode - false', function(t) {
+  tt.test('options.reverseGeocode - false by default', function(t) {
     t.plan(2);
-    setup({
-      reverseGeocode: false
-    });
+    setup();
     geocoder.query('34.5177548, -6.1933875');
     geocoder.on(
       'results',

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -117,7 +117,11 @@ test('geocoder', function(tt) {
       'results',
       once(function(e) {
         t.equal(e.features.length, 1, 'One result returned');
-        t.equal(e.features[0].place_name, 'Singida, Tanzania', 'returns expected result');
+        t.equal(
+          e.features[0].place_name,
+          'Singida, Tanzania',
+          'returns expected result'
+        );
         t.equal(e.config.limit, 1, 'sets limit to 1 for reverse geocodes');
       })
     );
@@ -136,10 +140,12 @@ test('geocoder', function(tt) {
         t.equal(e.features.length, 0, 'No results returned');
       })
     );
-    geocoder.on('error',
-    once(function(e) {
-      t.equal(e.error.statusCode, 422, 'should error')
-    }))
+    geocoder.on(
+      'error',
+      once(function(e) {
+        t.equal(e.error.statusCode, 422, 'should error');
+      })
+    );
   });
 
   tt.test('parses options correctly', function(t) {
@@ -159,9 +165,17 @@ test('geocoder', function(tt) {
       'results',
       once(function(e) {
         t.equal(e.features.length, 5, 'Five results returned');
-        t.deepEquals(e.config.language, languages, 'converts language options to array');
+        t.deepEquals(
+          e.config.language,
+          languages,
+          'converts language options to array'
+        );
         t.deepEquals(e.config.types, types, 'converts types options to array');
-        t.deepEquals(e.config.countries, countries, 'converts countries options to array')
+        t.deepEquals(
+          e.config.countries,
+          countries,
+          'converts countries options to array'
+        );
       })
     );
   });

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -127,12 +127,28 @@ test('geocoder', function(tt) {
     );
   });
 
+  tt.test('options.reverseGeocode - interprets coordinates correctly', function(t) {
+    t.plan(3);
+    setup({
+      types: 'country'
+    });
+    geocoder.query('-7.0926 31.791');
+    geocoder.on(
+      'results',
+      once(function(e) {
+        console.log(e);
+        t.deepEquals(e.query, [ -7.0926, 31.791 ], 'parses query');
+        t.deepEquals(e.config.types.toString(), 'country', 'uses correct type passed to config' );
+        t.equal(e.features[0].place_name, 'Morocco', 'returns expected result');
+      })
+    );
+  });
+
   tt.test('options.reverseGeocode - false', function(t) {
     t.plan(2);
     setup({
       reverseGeocode: false
     });
-
     geocoder.query('34.5177548, -6.1933875');
     geocoder.on(
       'results',


### PR DESCRIPTION
Based on concerns addressed in https://github.com/mapbox/mapbox-gl-geocoder/pull/175#issuecomment-456200161, this PR should help with backwards compatibility for some of our public examples that use the plugin.

- Makes `reverseGeocode` an option (defaults to true)
- Fixes string parsing while passing a list in to options when the client expects an array (for `countries`, `types`, and `languages`)
- Adds a test for 👆 to make sure that this is being done correctly
- Fixes coordinate parsing (if `reverseGeocode` is enabled)
- Appends `config` to `response` (so the config passed to the client is testable)

@andrewharvey now to use with https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-local-geocoder/, you could set `reverseGeocode: false` while initializing the geocoder. Doing so gives you the same result as the example using 2.3.0. However, it will still throw an error in the browser console since any coordinate-like query you send to our geocoding API attempts to reverse geocode (which is expected). I'm not sure the best way to handle this, but I think it's fine for now since the local geocoder still returns the same result and the console error doesn't affect the result. Let me know if you have any ideas.

closes #120