### PR TITLE
ensure proximity option is passed through to request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -191,6 +191,7 @@ MapboxGeocoder.prototype = {
     var keys = [
       'bbox',
       'limit',
+      'proximity',
       'countries',
       'types',
       'language',
@@ -205,6 +206,10 @@ MapboxGeocoder.prototype = {
         ['countries', 'types', 'language'].indexOf(key) > -1
           ? (config[key] = self.options[key].split(/[\s,]+/))
           : (config[key] = self.options[key]);
+
+        if (key === 'proximity' && self.options[key] && self.options[key].longitude && self.options[key].latitude) {
+          config[key] = [self.options[key].longitude, self.options[key].latitude]
+        }
       }
       return config;
     }, {});

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -399,5 +399,26 @@ test('geocoder', function(tt) {
     t.notOk(geocoder.getProximity(), 'proximity unset after zooming out');
   });
 
+  tt.test('options.setProximity', function(t) {
+    t.plan(1);
+
+    setup({});
+
+    map.setZoom(13);
+    map.setCenter([-79.4512, 43.6568]);
+    geocoder.setProximity({ longitude: -79.4512, latitude: 43.6568});
+
+    geocoder.query('high');
+    geocoder.on(
+      'results',
+      once(function(e) {
+        t.ok(
+          e.features[0].place_name.indexOf('Toronto') !== -1,
+          'proximity applied in geocoding request'
+        );
+      })
+    );
+  });
+
   tt.end();
 });


### PR DESCRIPTION
this fixes a regression in v3 which broke the proximity option, including a test