### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v3.1.2
 
-- Enable inaction event logging
+- Enable interaction event logging
 
 ### v3.1.1
 


### PR DESCRIPTION
Address the comment in #183 that notes that there was a typo in the changelog around the interaction event logging.