### PR TITLE
Fix -1 bug in selection event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.1.3
+
+- Fix bug where events were logging -1 as resultIndex
+
 ## v3.1.2
 
 - Enable interaction event logging

--- a/lib/events.js
+++ b/lib/events.js
@@ -44,9 +44,10 @@ MapboxEventManager.prototype = {
     var resultIndex = this.getSelectedIndex(selected, geocoder);
     var payload = this.getEventPayload('search.select', geocoder);
     payload.resultIndex = resultIndex;
-    if (resultIndex === this.lastSentIndex && payload.queryString === this.lastSentInput) {
+    if ((resultIndex === this.lastSentIndex && payload.queryString === this.lastSentInput) || resultIndex == -1) {
       // don't log duplicate events if the user re-selected the same feature on the same search
       if (callback) return callback();
+      else return;
     }
     this.lastSentIndex = resultIndex;
     this.lastSentInput = payload.queryString;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "style": "lib/mapbox-gl-geocoder.css",


### PR DESCRIPTION
Fixes a small bug related to https://github.com/mapbox/mapbox-gl-geocoder/issues/99 and https://github.com/tristen/suggestions/issues/13 (causing result selection events to be emitted twice). One of these events will record the selected index as `-1` while the other will record the actual index of the selection meaning our exisiting deduplication strategy did not work.

We should fix the upstream issue soon, however, this will fix the specific problem of having `-1` resultIndex's in the events produced by the `MapboxEventsManager`. 