### PR TITLE
Remove dependencies for events logging

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var https = require('https');
-var crypto = require('crypto');
+var shajs = require('sha.js')
 
 /**
  * Construct a new mapbox event client to send interaction events to the mapbox event service
@@ -182,9 +182,7 @@ MapboxEventManager.prototype = {
    * @private
    */
   generateSessionID: function () {
-    var sha = crypto.createHash('sha256');
-    sha.update(Math.random().toString());
-    return sha.digest('hex')
+    return new shajs.sha256().update(Math.random().toString()).digest('hex')
   },
 
   /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -215,7 +215,7 @@ MapboxEventManager.prototype = {
    * @private
    */
   shouldEnableLogging: function (options) {
-    if (!this.origin.includes('api.mapbox.com')) return false;
+    if (this.origin.indexOf('api.mapbox.com')  == -1) return false;
     // hard to make sense of events when a local instance is suplementing results from origin
     if (options.localGeocoder) return false;
     // hard to make sense of events when a custom filter is in use

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,8 +1,5 @@
 'use strict';
-
-var https = require('https');
 var shajs = require('sha.js')
-
 /**
  * Construct a new mapbox event client to send interaction events to the mapbox event service
  * @param {Object} options options with which to create the service
@@ -84,9 +81,8 @@ MapboxEventManager.prototype = {
       return callback();
     }
     var options = this.getRequestOptions(payload);
-    this.request(options, function (err, res) {
+    this.request(options, function (err) {
       if (err) return this.handleError(err, callback);
-      if (res.statusCode != 204) return this.handleError(res, callback);
       if (callback) return callback();
     })
   },
@@ -151,20 +147,23 @@ MapboxEventManager.prototype = {
    * @param {Function} callback the callback to invoke when the http request is completed
    */
   request: function (opts, callback) {
-    https.request(opts, function (resp) {
-
-      var data = '';
-      resp.on('data', function (chunk) {
-        data += chunk;
-      });
-      resp.on('end', function () {
-        callback(null, data)
-      });
-
-    }).on("error", function (err) {
-      console.error(err)
-      callback(err);
-    });
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (this.readyState == 4 ) {
+        if (this.status == 204){
+            //success
+          return callback(null);
+        }else {
+          return callback(this.statusText);
+        }
+      }
+    };
+    xhttp.open(opts.method, opts.host + opts.path, true);
+    for (var header in opts.headers){
+      var headerValue = opts.headers[header];
+      xhttp.setRequestHeader(header, headerValue)
+    }
+    xhttp.send(opts.body);
   },
 
   /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var request = require('request');
+var https = require('https');
 var crypto = require('crypto');
 
 /**
@@ -9,16 +9,16 @@ var crypto = require('crypto');
  * @param {String} options.accessToken the mapbox access token to make requests
  * @private
  */
-function MapboxEventManager(options){
+function MapboxEventManager(options) {
   this.origin = options.origin || 'https://api.mapbox.com';
-  this.endpoint = this.origin + '/events/v2';
+  this.endpoint = '/events/v2';
   this.access_token = options.accessToken;
   this.version = '0.0.1'
   this.sessionID = this.generateSessionID();
   this.userAgent = this.getUserAgent();
   // parse global options to be sent with each request
-  this.countries =  (options.countries) ? options.countries.split(",") : null;
-  this.types =  (options.types) ? options.types.split(",") : null;
+  this.countries = (options.countries) ? options.countries.split(",") : null;
+  this.types = (options.types) ? options.types.split(",") : null;
   this.bbox = (options.bbox) ? options.bbox : null;
   this.language = (options.language) ? options.language.split(",") : null;
   this.limit = (options.limit) ? +options.limit : null;
@@ -32,15 +32,15 @@ function MapboxEventManager(options){
 MapboxEventManager.prototype = {
 
   /**
-     * Send a search.select event to the mapbox events service
-     * This event marks the array index of the item selected by the user out of the array of possible options
-     * @private
-     * @param {Object} selected the geojson feature selected by the user
-     * @param {Object} geocoder a mapbox-gl-geocoder instance
-     * @param {Function} callback a callback function to invoke once the event has been sent (optional)
-     * @returns {Promise}
-     */
-  select: function(selected, geocoder, callback){
+   * Send a search.select event to the mapbox events service
+   * This event marks the array index of the item selected by the user out of the array of possible options
+   * @private
+   * @param {Object} selected the geojson feature selected by the user
+   * @param {Object} geocoder a mapbox-gl-geocoder instance
+   * @param {Function} callback a callback function to invoke once the event has been sent (optional)
+   * @returns {Promise}
+   */
+  select: function (selected, geocoder, callback) {
     var resultIndex = this.getSelectedIndex(selected, geocoder);
     var payload = this.getEventPayload('search.select', geocoder);
     payload.resultIndex = resultIndex;
@@ -55,34 +55,36 @@ MapboxEventManager.prototype = {
   },
 
   /**
-     * Send a search-start event to the mapbox events service
-     * This turnstile event marks when a user starts a new search
-     * @private
-     * @param {Object} geocoder a mapbox-gl-geocoder instance
-     * @param {Function} callback 
-     * @returns {Promise}
-     */
-  start: function(geocoder, callback){
+   * Send a search-start event to the mapbox events service
+   * This turnstile event marks when a user starts a new search
+   * @private
+   * @param {Object} geocoder a mapbox-gl-geocoder instance
+   * @param {Function} callback 
+   * @returns {Promise}
+   */
+  start: function (geocoder, callback) {
     var payload = this.getEventPayload('search.start', geocoder);
     return this.send(payload, callback);
   },
 
   /**
-     * Send an event to the events service
-     * 
-     * The event is skipped if the instance is not enabled to send logging events
-     * 
-     * @private
-     * @param {Object} payload the http POST body of the event
-     * @returns {Promise}
-     */
-  send: function(payload, callback){
-    if (!callback) callback = function(){return};
-    if (!this.enableEventLogging){ 
+   * Send an event to the events service
+   * 
+   * The event is skipped if the instance is not enabled to send logging events
+   * 
+   * @private
+   * @param {Object} payload the http POST body of the event
+   * @returns {Promise}
+   */
+  send: function (payload, callback) {
+    if (!callback) callback = function () {
+      return
+    };
+    if (!this.enableEventLogging) {
       return callback();
     }
     var options = this.getRequestOptions(payload);
-    this.request(options, function(err,res){
+    this.request(options, function (err, res) {
       if (err) return this.handleError(err, callback);
       if (res.statusCode != 204) return this.handleError(res, callback);
       if (callback) return callback();
@@ -93,45 +95,43 @@ MapboxEventManager.prototype = {
    * @private
    * @param {*} payload 
    */
-  getRequestOptions: function(payload){
+  getRequestOptions: function (payload) {
     var options = {
       // events must be sent with POST
-      method: "POST", 
-      url: this.endpoint,
-      headers:{
+      method: "POST",
+      host: this.origin,
+      path: this.endpoint +  "?access_token=" + this.access_token,
+      headers: {
         'Content-Type': 'application/json'
       },
-      qs: {
-        access_token: this.access_token
-      },
-      body:JSON.stringify([payload]) //events are arrays
+      body: JSON.stringify([payload]) //events are arrays
     }
     return options
   },
 
   /**
-     * Get the event payload to send to the events service
-     * Most payload properties are shared across all events
-     * @private
-     * @param {String} event the name of the event to send to the events service. Valid options are 'search.start', 'search.select', 'search.feedback'.
-     * @param {Object} geocoder a mapbox-gl-geocoder instance 
-     * @returns {Object} an event payload 
-     */
-  getEventPayload: function(event, geocoder){
+   * Get the event payload to send to the events service
+   * Most payload properties are shared across all events
+   * @private
+   * @param {String} event the name of the event to send to the events service. Valid options are 'search.start', 'search.select', 'search.feedback'.
+   * @param {Object} geocoder a mapbox-gl-geocoder instance 
+   * @returns {Object} an event payload 
+   */
+  getEventPayload: function (event, geocoder) {
     var proximity;
     if (!geocoder.options.proximity) proximity = null;
-    else proximity = [geocoder.options.proximity.longitude, geocoder.options.proximity.latitude ];
+    else proximity = [geocoder.options.proximity.longitude, geocoder.options.proximity.latitude];
 
     var zoom = (geocoder._map) ? geocoder._map.getZoom() : null;
     return {
       event: event,
       created: +new Date(),
       sessionIdentifier: this.sessionID,
-      country: this.countries, 
+      country: this.countries,
       userAgent: this.userAgent,
       language: this.language,
       bbox: this.bbox,
-      types: this.types, 
+      types: this.types,
       endpoint: 'mapbox.places',
       // fuzzyMatch: search.fuzzy, //todo  --> add to plugin
       proximity: proximity,
@@ -139,62 +139,73 @@ MapboxEventManager.prototype = {
       // routing: search.routing, //todo --> add to plugin
       queryString: geocoder.inputString,
       mapZoom: zoom,
-      keyboardLocale: this.locale 
+      keyboardLocale: this.locale
     }
   },
 
   /**
-     * Wraps the request function for easier testing
-     * Make an http request and invoke a callback
-     * @private
-     * @param {Object} opts options describing the http request to be made
-     * @param {Function} callback the callback to invoke when the http request is completed
-     */
-  request: function(opts, callback){
-    request(opts, function(err, res){
-      return callback(err, res);
-    })
+   * Wraps the request function for easier testing
+   * Make an http request and invoke a callback
+   * @private
+   * @param {Object} opts options describing the http request to be made
+   * @param {Function} callback the callback to invoke when the http request is completed
+   */
+  request: function (opts, callback) {
+    https.request(opts, function (resp) {
+
+      var data = '';
+      resp.on('data', function (chunk) {
+        data += chunk;
+      });
+      resp.on('end', function () {
+        callback(null, data)
+      });
+
+    }).on("error", function (err) {
+      console.error(err)
+      callback(err);
+    });
   },
 
   /**
-     * Handle an error that occurred while making a request
-     * @param {Object} err an error instance to log
-     * @private
-     */
-  handleError: function(err, callback){
+   * Handle an error that occurred while making a request
+   * @param {Object} err an error instance to log
+   * @private
+   */
+  handleError: function (err, callback) {
     if (callback) return callback(err);
   },
 
   /**
-     * Generate a session ID to be returned with all of the searches made by this geocoder instance
-     * ID is random and cannot be tracked across sessions
-     * @private
-     */
-  generateSessionID: function(){
+   * Generate a session ID to be returned with all of the searches made by this geocoder instance
+   * ID is random and cannot be tracked across sessions
+   * @private
+   */
+  generateSessionID: function () {
     var sha = crypto.createHash('sha256');
     sha.update(Math.random().toString());
     return sha.digest('hex')
   },
 
   /**
-     * Get a user agent string to send with the request to the events service
-     * @private
-     */
-  getUserAgent: function(){
+   * Get a user agent string to send with the request to the events service
+   * @private
+   */
+  getUserAgent: function () {
     return 'mapbox-gl-geocoder.' + this.version + "." + navigator.userAgent;
   },
 
   /**
-     * Get the 0-based numeric index of the item that the user selected out of the list of options
-     * @private
-     * @param {Object} selected the geojson feature selected by the user
-     * @param {Object} geocoder a Mapbox-GL-Geocoder instance
-     * @returns {Number} the index of the selected result
-     */
-  getSelectedIndex: function(selected, geocoder){
+   * Get the 0-based numeric index of the item that the user selected out of the list of options
+   * @private
+   * @param {Object} selected the geojson feature selected by the user
+   * @param {Object} geocoder a Mapbox-GL-Geocoder instance
+   * @returns {Number} the index of the selected result
+   */
+  getSelectedIndex: function (selected, geocoder) {
     var results = geocoder._typeahead.data;
     var selectedID = selected.id;
-    var resultIDs = results.map(function (feature){
+    var resultIDs = results.map(function (feature) {
       return feature.id;
     });
     var selectedIdx = resultIDs.indexOf(selectedID);
@@ -202,11 +213,11 @@ MapboxEventManager.prototype = {
   },
 
   /**
-     * Check whether events should be logged
-     * Clients using a localGeocoder or an origin other than mapbox should not have events logged
-     * @private
-     */
-  shouldEnableLogging: function(options){
+   * Check whether events should be logged
+   * Clients using a localGeocoder or an origin other than mapbox should not have events logged
+   * @private
+   */
+  shouldEnableLogging: function (options) {
     if (!this.origin.includes('api.mapbox.com')) return false;
     // hard to make sense of events when a local instance is suplementing results from origin
     if (options.localGeocoder) return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "3.1.1",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8989,7 +8989,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@mapbox/mapbox-sdk": "^0.5.0",
     "lodash.debounce": "^4.0.6",
-    "request": "^2.88.0",
     "sha.js": "^2.4.11",
     "sinon": "^7.2.3",
     "suggestions": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@mapbox/mapbox-sdk": "^0.5.0",
     "lodash.debounce": "^4.0.6",
     "request": "^2.88.0",
+    "sha.js": "^2.4.11",
     "sinon": "^7.2.3",
     "suggestions": "^1.3.2",
     "xtend": "^4.0.1"

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -15,7 +15,7 @@ test('it constructs a new event manager instance with the correct properties', f
         limit: 2
     }
     var eventsManager = new MapboxEventsManager(options)
-    assert.equals(eventsManager.endpoint, 'https://api.mapbox.com/events/v2', 'the correct event endpoint is set');
+    assert.equals(eventsManager.endpoint, '/events/v2', 'the correct event endpoint is set');
     assert.equals(eventsManager.access_token, options.accessToken, 'sets the right access tokens for the request');
     assert.deepEqual(eventsManager.countries, ['CA', 'US'], 'correctly parses the country parameter into an array');
     assert.deepEqual(eventsManager.language, ['en', 'fr'], 'correctly parses the language parameter into an array');
@@ -75,9 +75,9 @@ test('get requst options', function(assert){
         event: 'test.event'
     };
     assert.equals(eventsManager.getRequestOptions(payload).method, 'POST', 'http method is set to POST');
-    assert.equals(eventsManager.getRequestOptions(payload).url, 'https://api.mapbox.com/events/v2', 'http request is made to the right uri');
+    assert.equals(eventsManager.getRequestOptions(payload).host, 'https://api.mapbox.com', 'http request is made to the right host');
+    assert.equals(eventsManager.getRequestOptions(payload).path, '/events/v2?access_token=abc123', 'http request is made to the right host');
     assert.deepEqual(eventsManager.getRequestOptions(payload).headers, {'Content-Type': 'application/json'}, 'content type is json');
-    assert.equals(eventsManager.getRequestOptions(payload).qs.access_token, 'abc123', 'http request is sent with the right access token');
     assert.deepEqual(eventsManager.getRequestOptions(payload).body, JSON.stringify([payload]), 'the right payload is set for the request');
     assert.end();
 })


### PR DESCRIPTION
In response to #188, this PR investigates the increase in bundle size introduced in #183 and attempts to reduce the increase by changing the dependencies used in logging interaction events. 
