### PR TITLE
Fire clear event on empty search box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v3.1.4
+
+- Emit a `clear` event when the user backspaces into an empty search bar or selects all existing text and deletes it.
+
+
 ## v3.1.3
 
 - Fix bug where events were logging -1 as resultIndex

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,12 +145,15 @@ MapboxGeocoder.prototype = {
   },
 
   _onKeyDown: debounce(function(e) {
+    
     // if target has shadowRoot, then get the actual active element inside the shadowRoot
     var target = e.target.shadowRoot
       ? e.target.shadowRoot.activeElement
       : e.target;
     if (!target.value) {
       this.fresh = true;
+      // the user has removed all the text
+      this._clear(e);
       return (this._clearEl.style.display = 'none');
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",


### PR DESCRIPTION
Addresses #155 by firing a `clear` event when the user backspaces into an empty search box or when the user highlights all the text and deletes it. 