### PR TITLE
Obtain language from browser by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,7 @@
     -   [setInput](#setinput)
     -   [setProximity](#setproximity)
     -   [getProximity](#getproximity)
+    -   [getLanguage](#getlanguage)
     -   [on](#on)
     -   [off](#off)
 
@@ -88,6 +89,14 @@ Returns **[MapboxGeocoder](#mapboxgeocoder)** this
 Get proximity
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** The geocoder proximity
+
+### getLanguage
+
+Get the language to use in UI elements and when making search requests
+
+Look first at the explicitly set options otherwise use the browser's language settings
+
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The language used by the geocoder
 
 ### on
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Obtain language from user's browser settings [#195](https://github.com/mapbox/mapbox-gl-geocoder/issues/195)
+
 ## v3.1.4
 
 - Emit a `clear` event when the user backspaces into an empty search bar or selects all existing text and deletes it.

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var exceptions = require('./exceptions');
 var MapboxClient = require('@mapbox/mapbox-sdk');
 var mbxGeocoder = require('@mapbox/mapbox-sdk/services/geocoding');
 var MapboxEventManager = require('./events');
+// var subtag = require('subtag');
 var geocoderService;
 
 /**
@@ -68,6 +69,8 @@ MapboxGeocoder.prototype = {
 
   onAdd: function(map) {
     this._map = map;
+
+    this.options.language = this.getLanguage();
 
     geocoderService = mbxGeocoder(
       MapboxClient({
@@ -386,6 +389,17 @@ MapboxGeocoder.prototype = {
    */
   getProximity: function() {
     return this.options.proximity;
+  },
+
+  /**
+   * Get the language to use in UI elements and when making search requests
+   * 
+   * Look first at the explicitly set options otherwise use the browser's language settings
+   */
+  getLanguage: function(){
+    var browserLocale = navigator.language || navigator.userLanguage || navigator.browserLanguage;
+    console.log(browserLocale);
+    return this.options.language || browserLocale;
   },
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -395,6 +395,8 @@ MapboxGeocoder.prototype = {
    * Get the language to use in UI elements and when making search requests
    * 
    * Look first at the explicitly set options otherwise use the browser's language settings
+   * 
+   * @returns {String} The language used by the geocoder
    */
   getLanguage: function(){
     var browserLocale = navigator.language || navigator.userLanguage || navigator.browserLanguage;

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -121,7 +121,7 @@ test('geocoder', function(tt) {
   });
 
   tt.test('options.reverseGeocode - true', function(t) {
-    t.plan(3);
+    t.plan(4);
     setup({
       reverseGeocode: true
     });
@@ -130,9 +130,12 @@ test('geocoder', function(tt) {
       'results',
       once(function(e) {
         t.equal(e.features.length, 1, 'One result returned');
-        t.equal(
-          e.features[0].place_name,
-          'Singida, Tanzania',
+        t.ok(
+          e.features[0].place_name.indexOf('Tanzania') > -1, 
+          'returns expected result'
+        );
+        t.ok(
+          e.features[0].place_name.indexOf('Singida') > -1, 
           'returns expected result'
         );
         t.equal(e.config.limit, 1, 'sets limit to 1 for reverse geocodes');

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -84,5 +84,20 @@ test('Geocoder#inputControl', function(tt) {
     t.end();
   });
 
+  tt.test('get language when a language is provided in the options', function(t){
+    t.plan(1);
+    setup({language: 'en-UK'});
+    t.equals(geocoder.options.language, 'en-UK', 'uses the right language when set directly as an option');
+  });
+
+  tt.test('get language when a language obtained from the browser', function(t){
+    t.plan(3);
+    setup({});
+    t.ok(geocoder.options.language, 'language is defined');
+    t.ok(typeof(geocoder.options.language), 'string', 'language is defined  as a string');
+    t.ok(geocoder.options.language.split("-").length, 2, 'language is defined as an iso tag with a subtag');
+  })
+
+
   tt.end();
 });


### PR DESCRIPTION
As per #195, this PR checks the browser's `language` tag and uses this by default when making searches if another language is not already set in the constructor options.

This also unblocks #150, which we can handle next.

\cc @katydecorah @kbauhaus @yuletide 