### PR TITLE
set trackProximity to true by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ A geocoder component using Mapbox Geocoding API
         a geographical point given as an object with latitude and longitude
         properties. Search results closer to this point will be given
         higher priority.
-    -   `options.trackProximity` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, the geocoder proximity will automatically update based on the map view. (optional, default `false`)
+    -   `options.trackProximity` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
     -   `options.bbox` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** a bounding box argument: this is
         a bounding box given as an array in the format [minX, minY, maxX, maxY].
         Search results will be limited to the bounding box.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- `trackProximity` turned on by default [#195](https://github.com/mapbox/mapbox-gl-geocoder/issues/195)
+
 ## v3.1.4
 
 - Emit a `clear` event when the user backspaces into an empty search bar or selects all existing text and deletes it.

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ var geocoderService;
  * a geographical point given as an object with latitude and longitude
  * properties. Search results closer to this point will be given
  * higher priority.
- * @param {Boolean} [options.trackProximity=false] If true, the geocoder proximity will automatically update based on the map view.
+ * @param {Boolean} [options.trackProximity=true] If true, the geocoder proximity will automatically update based on the map view.
  * @param {Array} [options.bbox] a bounding box argument: this is
  * a bounding box given as an array in the format [minX, minY, maxX, maxY].
  * Search results will be limited to the bounding box.
@@ -59,7 +59,7 @@ MapboxGeocoder.prototype = {
     placeholder: 'Search',
     zoom: 16,
     flyTo: true,
-    trackProximity: false,
+    trackProximity: true,
     minLength: 2,
     reverseGeocode: false,
     limit: 5,

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -27,6 +27,7 @@ test('geocoder', function(tt) {
     t.ok(geocoder.fresh, 'geocoder is initialized with fresh status to enable turnstile event');
     t.equals(geocoder.inputString, '', 'geocoder is initialized with an input string for keeping track of state');
     t.ok(geocoder.eventManager instanceof mapboxEvents, 'the geocoder has a mapbox event manager');
+    t.true(geocoder.options.trackProximity, 'sets trackProximity to true by default');
     t.end();
   });
 
@@ -408,6 +409,16 @@ test('geocoder', function(tt) {
 
     map.setZoom(9);
     t.notOk(geocoder.getProximity(), 'proximity unset after zooming out');
+  });
+
+  tt.test('options.trackProximity=false', function(t) {
+    t.plan(2);
+
+    setup({
+      trackProximity: false
+    });
+    t.false(geocoder.options.trackProximity, 'track proximity is set to false');
+    t.notOk(geocoder.getProximity(), 'proximity is not available when trackProximity is set to false');
   });
 
   tt.test('options.setProximity', function(t) {


### PR DESCRIPTION
Per #195, this sets the `trackProximity` option to true by default to improve search relevance by using the context provided by the map's center.