### PR TITLE
v3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.1.6
+-  Resolve npm publish failure
+
 ## v3.1.5
 
 - Reduce bundle size by removing unnecessary dependencies needed for event logging [#188](https://github.com/mapbox/mapbox-gl-geocoder/issues/188)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",


### PR DESCRIPTION
Release version v3.1.6 to resolve a npm publish failure on v3.1.5

- [ ] npm run prepublish 
- [x] npm run test
- [ ] push tag
- [ ] npm publish
- [ ] Update version number in GL JS examples

\cc @katydecorah 