### PR TITLE
bump suggestions to v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - `trackProximity` turned on by default [#195](https://github.com/mapbox/mapbox-gl-geocoder/issues/195)
+- Bump suggestions to v1.3.4
 
 ## v3.1.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "3.1.1",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9962,9 +9962,9 @@
       }
     },
     "suggestions": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/suggestions/-/suggestions-1.3.3.tgz",
-      "integrity": "sha512-b5TVbiDvdkUExGVhasglcehIiY1C1MxksWCHCi2Ie8xot08SkvnH3Icb/qnxNMiMr48eI0OPdr53JuB9Ryd04g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/suggestions/-/suggestions-1.3.4.tgz",
+      "integrity": "sha512-dzBIUp/oQ79sEctw5Ac7ufg49/kgykzmddWMuU6wIJ7bSVlpdmcrkRF8UYCFBD2HtUfVwURrkJcmfLNAUr4WZg==",
       "requires": {
         "fuzzy": "^0.1.1",
         "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash.debounce": "^4.0.6",
     "request": "^2.88.0",
     "sinon": "^7.2.3",
-    "suggestions": "^1.3.2",
+    "suggestions": "^1.3.4",
     "xtend": "^4.0.1"
   }
 }


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Bumps the suggestions library to v1.3.4 to take advantage of the changes made in https://github.com/tristen/suggestions/pull/24. 

\ref #162 

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] update CHANGELOG.md with changes under `master` heading before merging
