### PR TITLE
Deduplicate result event emissions (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Localize placeholder based on language set in constructor options [#150](https://github.com/mapbox/mapbox-gl-geocoder/issues/150)
 - `trackProximity` turned on by default [#195](https://github.com/mapbox/mapbox-gl-geocoder/issues/195)
 - Bump suggestions to v1.3.4
+- Fix duplicate event bug
 
 ## v3.1.4
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ function MapboxGeocoder(options) {
   this.options = extend({}, this.options, options);
   this.inputString = '';
   this.fresh = true;
+  this.lastSelected = null;
 }
 
 MapboxGeocoder.prototype = {
@@ -190,8 +191,12 @@ MapboxGeocoder.prototype = {
           });
         }
       }
-      this._eventEmitter.emit('result', { result: selected });
-      this.eventManager.select(selected, this);
+      if (selected.id !== this.lastSelected){
+        console.log("gl:result")
+        this._eventEmitter.emit('result', { result: selected });
+        this.eventManager.select(selected, this);
+        this.lastSelected =  selected.id;
+      }
     }
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,6 @@ MapboxGeocoder.prototype = {
         }
       }
       if (selected.id !== this.lastSelected){
-        console.log("gl:result")
         this._eventEmitter.emit('result', { result: selected });
         this.eventManager.select(selected, this);
         this.lastSelected =  selected.id;


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
This PR addresses the bug reported in #99 by keeping a state variable indicating the last selected feature. 

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] update CHANGELOG.md with changes under `master` heading before merging

\cc @katydecorah @yuletide 
