### PR TITLE
add `npm run docs` step to template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,5 @@
 
  - [ ] briefly describe the changes in this PR
  - [ ] write tests for all new functionality
+ - [ ] run `npm run docs` and commit changes to API.md
  - [ ] update CHANGELOG.md with changes under `master` heading before merging


### PR DESCRIPTION
Adds step to PR template to run `npm run docs` and commit changes to API.md
