### PR TITLE
Pass camera options to map.fitBounds

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,93 +2,121 @@
 
 ### Table of Contents
 
--   [MapboxGeocoder](#mapboxgeocoder)
-    -   [query](#query)
-    -   [setInput](#setinput)
-    -   [setProximity](#setproximity)
-    -   [getProximity](#getproximity)
-    -   [getLanguage](#getlanguage)
-    -   [on](#on)
-    -   [off](#off)
+-   [MapboxGeocoder][1]
+    -   [Parameters][2]
+    -   [Examples][3]
+    -   [query][4]
+        -   [Parameters][5]
+    -   [setInput][6]
+        -   [Parameters][7]
+    -   [setProximity][8]
+        -   [Parameters][9]
+    -   [getProximity][10]
+    -   [setRenderFunction][11]
+        -   [Parameters][12]
+    -   [getRenderFunction][13]
+    -   [getLanguage][14]
+    -   [on][15]
+        -   [Parameters][16]
+    -   [off][17]
+        -   [Parameters][18]
 
 ## MapboxGeocoder
 
 A geocoder component using Mapbox Geocoding API
 
-**Parameters**
+### Parameters
 
--   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-    -   `options.accessToken` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Required.
-    -   `options.origin` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Use to set a custom API origin. Defaults to <https://api.mapbox.com>.
-    -   `options.zoom` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
-    -   `options.flyTo` **([Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))?** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the flyTo map method to specify a custom animation.
-    -   `options.placeholder` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Override the default placeholder attribute value. (optional, default `"Search"`)
-    -   `options.proximity` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** a proximity argument: this is
+-   `options` **[Object][19]** 
+    -   `options.accessToken` **[String][20]** Required.
+    -   `options.origin` **[String][20]** Use to set a custom API origin. Defaults to [https://api.mapbox.com][21].
+    -   `options.zoom` **[Number][22]** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
+    -   `options.flyTo` **([Boolean][23] \| [Object][19])?** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the map method to specify a custom animation when a result is selected.
+    -   `options.placeholder` **[String][20]** Override the default placeholder attribute value. (optional, default `"Search"`)
+    -   `options.proximity` **[Object][19]?** a proximity argument: this is
         a geographical point given as an object with latitude and longitude
         properties. Search results closer to this point will be given
         higher priority.
-    -   `options.trackProximity` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
-    -   `options.bbox` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** a bounding box argument: this is
+    -   `options.trackProximity` **[Boolean][23]** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
+    -   `options.bbox` **[Array][24]?** a bounding box argument: this is
         a bounding box given as an array in the format [minX, minY, maxX, maxY].
         Search results will be limited to the bounding box.
-    -   `options.countries` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a comma separated list of country codes to
+    -   `options.countries` **[string][20]?** a comma separated list of country codes to
         limit results to specified country or countries.
-    -   `options.types` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a comma seperated list of types that filter
-        results to match those specified. See <https://docs.mapbox.com/api/search/#data-types>
+    -   `options.types` **[string][20]?** a comma seperated list of types that filter
+        results to match those specified. See [https://docs.mapbox.com/api/search/#data-types][25]
         for available types.
         If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used.
-    -   `options.minLength` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Minimum number of characters to enter before results are shown. (optional, default `2`)
-    -   `options.limit` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum number of results to show. (optional, default `5`)
-    -   `options.language` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
-    -   `options.filter` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
-    -   `options.localGeocoder` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
+    -   `options.minLength` **[Number][22]** Minimum number of characters to enter before results are shown. (optional, default `2`)
+    -   `options.limit` **[Number][22]** Maximum number of results to show. (optional, default `5`)
+    -   `options.language` **[string][20]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
+    -   `options.filter` **[Function][26]?** A function which accepts a Feature in the [Carmen GeoJSON][27] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+    -   `options.localGeocoder` **[Function][26]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON][27] format.
     -   `options.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
-    -   `options.reverseGeocode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
+    -   `options.reverseGeocode` **[boolean][23]?** Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
+    -   `options.render` **[Function][26]?** A function that specifies how the results should be rendered in the dropdown menu
+    -   `options.getItemValue` **[Function][26]?** A function that specifies how the selected result should be rendered in the search bar
 
-**Examples**
+### Examples
 
 ```javascript
 var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
 map.addControl(geocoder);
 ```
 
-Returns **[MapboxGeocoder](#mapboxgeocoder)** `this`
+Returns **[MapboxGeocoder][28]** `this`
 
 ### query
 
 Set & query the input
 
-**Parameters**
+#### Parameters
 
--   `searchInput` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** location name or other search input
+-   `searchInput` **[string][20]** location name or other search input
 
-Returns **[MapboxGeocoder](#mapboxgeocoder)** this
+Returns **[MapboxGeocoder][28]** this
 
 ### setInput
 
 Set input
 
-**Parameters**
+#### Parameters
 
--   `searchInput` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** location name or other search input
+-   `searchInput` **[string][20]** location name or other search input
 
-Returns **[MapboxGeocoder](#mapboxgeocoder)** this
+Returns **[MapboxGeocoder][28]** this
 
 ### setProximity
 
 Set proximity
 
-**Parameters**
+#### Parameters
 
--   `proximity` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** The new options.proximity value. This is a geographical point given as an object with latitude and longitude properties.
+-   `proximity` **[Object][19]** The new options.proximity value. This is a geographical point given as an object with latitude and longitude properties.
 
-Returns **[MapboxGeocoder](#mapboxgeocoder)** this
+Returns **[MapboxGeocoder][28]** this
 
 ### getProximity
 
 Get proximity
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** The geocoder proximity
+Returns **[Object][19]** The geocoder proximity
+
+### setRenderFunction
+
+Set the render function used in the results dropdown
+
+#### Parameters
+
+-   `fn` **[Function][26]** The function to use as a render function
+
+Returns **[MapboxGeocoder][28]** this
+
+### getRenderFunction
+
+Get the function used to render the results dropdown
+
+Returns **[Function][26]** the render function
 
 ### getLanguage
 
@@ -96,30 +124,86 @@ Get the language to use in UI elements and when making search requests
 
 Look first at the explicitly set options otherwise use the browser's language settings
 
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The language used by the geocoder
+Returns **[String][20]** The language used by the geocoder
 
 ### on
 
 Subscribe to events that happen within the plugin.
 
-**Parameters**
+#### Parameters
 
--   `type` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
+-   `type` **[String][20]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
     -   **loading** `{ query } Emitted when the geocoder is looking up a query`
     -   **results** `{ results } Fired when the geocoder returns a response`
     -   **result** `{ result } Fired when input is set`
     -   **error** `{ error } Error as string`
--   `fn` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function that's called when the event is emitted.
+-   `fn` **[Function][26]** function that's called when the event is emitted.
 
-Returns **[MapboxGeocoder](#mapboxgeocoder)** this;
+Returns **[MapboxGeocoder][28]** this;
 
 ### off
 
 Remove an event
 
-**Parameters**
+#### Parameters
 
--   `type` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Event name.
--   `fn` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Function that should unsubscribe to the event emitted.
+-   `type` **[String][20]** Event name.
+-   `fn` **[Function][26]** Function that should unsubscribe to the event emitted.
 
-Returns **[MapboxGeocoder](#mapboxgeocoder)** this
+Returns **[MapboxGeocoder][28]** this
+
+[1]: #mapboxgeocoder
+
+[2]: #parameters
+
+[3]: #examples
+
+[4]: #query
+
+[5]: #parameters-1
+
+[6]: #setinput
+
+[7]: #parameters-2
+
+[8]: #setproximity
+
+[9]: #parameters-3
+
+[10]: #getproximity
+
+[11]: #setrenderfunction
+
+[12]: #parameters-4
+
+[13]: #getrenderfunction
+
+[14]: #getlanguage
+
+[15]: #on
+
+[16]: #parameters-5
+
+[17]: #off
+
+[18]: #parameters-6
+
+[19]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+[20]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[21]: https://api.mapbox.com
+
+[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[25]: https://docs.mapbox.com/api/search/#data-types
+
+[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+
+[27]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+
+[28]: #mapboxgeocoder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Master
-- Pass `flyTo` options to the map on result selection.
+- Pass `flyTo` options to the map on result selection on both map#flyTo and map#fitBounds operations [#214](https://github.com/mapbox/mapbox-gl-geocoder/pull/214)  and [#227](https://github.com/mapbox/mapbox-gl-geocoder/pull/227)
 - Obtain language from user's browser settings [#195](https://github.com/mapbox/mapbox-gl-geocoder/issues/195)
 - Localize placeholder based on language set in constructor options [#150](https://github.com/mapbox/mapbox-gl-geocoder/issues/150)
 - `trackProximity` turned on by default [#195](https://github.com/mapbox/mapbox-gl-geocoder/issues/195)

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var geocoderService;
  * @param {String} options.accessToken Required.
  * @param {String} options.origin Use to set a custom API origin. Defaults to https://api.mapbox.com.
  * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
- * @param {Boolean|Object} [options.flyTo] If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the flyTo map method to specify a custom animation. 
+ * @param {Boolean|Object} [options.flyTo] If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the map method to specify a custom animation when a result is selected. 
  * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
  * @param {Object} [options.proximity] a proximity argument: this is
  * a geographical point given as an object with latitude and longitude
@@ -181,9 +181,11 @@ MapboxGeocoder.prototype = {
     var selected = this._typeahead.selected;
     if (selected) {
       if (this.options.flyTo) {
+        var flyOptions;
         if (selected.properties && !exceptions[selected.properties.short_code] && selected.bbox) {
           var bbox = selected.bbox;
-          this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]]);
+          flyOptions = extend({}, this.options.flyTo);
+          this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
         } else if (selected.properties && exceptions[selected.properties.short_code]) {
           // Certain geocoder search results return (and therefore zoom to fit)
           // an unexpectedly large bounding box: for example, both Russia and the
@@ -191,13 +193,15 @@ MapboxGeocoder.prototype = {
           // Reunion in the Indian Ocean. An incomplete list of these exceptions
           // at ./exceptions.json provides "reasonable" bounding boxes as a
           // short-term solution; this may be amended as necessary.
-          this._map.fitBounds(exceptions[selected.properties.short_code].bbox);
+          flyOptions = extend({}, this.options.flyTo);
+          this._map.fitBounds(exceptions[selected.properties.short_code].bbox, flyOptions);
         } else {
           var defaultFlyOptions = {
-            center: selected.center,
             zoom: this.options.zoom
           }
-          var flyOptions = extend({}, this.options.flyTo, defaultFlyOptions);
+          flyOptions = extend({}, defaultFlyOptions, this.options.flyTo);
+          //  ensure that center is not overriden by custom options
+          flyOptions.center = selected.center;
           this._map.flyTo(flyOptions);
         }
       }

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -581,11 +581,53 @@ test('geocoder', function(tt) {
         t.ok(mapFlyMethod.calledOnce, "The map flyTo was called when the option was set to true");
         var calledWithArgs = mapFlyMethod.args[0][0];
         t.deepEqual(calledWithArgs.center, [ -122.47846, 37.819378 ], 'the selected result overrides the constructor center option');
-        t.deepEqual(calledWithArgs.zoom, 16, 'the selected result overrides the constructor zoom optiopn');
+        t.deepEqual(calledWithArgs.zoom, 4, 'the selected result overrides the constructor zoom option');
         t.deepEqual(calledWithArgs.speed, 5, 'speed argument is passed to the flyTo method');
       })
     );
-  })
+  });
+
+
+  tt.test('options.flyTo object on feature with bounding box', function(t){
+    t.plan(2 )
+    setup({
+      flyTo: {
+        speed: 5
+      }
+    });
+
+    var mapFlyMethod =  sinon.spy(map, "fitBounds");
+    geocoder.query('Brazil');
+    geocoder.on(
+      'result',
+      once(function() {
+        t.ok(mapFlyMethod.calledOnce, "The map flyTo was called when the option was set to true");
+        var calledWithArgs = mapFlyMethod.args[0][1];
+        t.deepEqual(calledWithArgs.speed, 5, 'speed argument is passed to the flyTo method');
+      })
+    );
+  });
+
+
+  tt.test('options.flyTo object on bounding box excepted feature', function(t){
+    t.plan(2)
+    setup({
+      flyTo: {
+        speed: 5
+      }
+    });
+
+    var mapFlyMethod =  sinon.spy(map, "fitBounds");
+    geocoder.query('Canada');
+    geocoder.on(
+      'result',
+      once(function() {
+        t.ok(mapFlyMethod.calledOnce, "The map flyTo was called when the option was set to true");
+        var calledWithArgs = mapFlyMethod.args[0][1];
+        t.deepEqual(calledWithArgs.speed, 5, 'speed argument is passed to the flyTo method');
+      })
+    );
+  });
 
   tt.test('placeholder localization', function(t){
     var ensureLanguages = ['de', 'en', 'fr', 'it', 'nl', 'ca', 'cs', 'fr', 'he', 'hu', 'is', 'ja', 'ka', 'ko', 'lv', 'ka', 'ko', 'lv', 'nb', 'pl', 'pt', 'sk', 'sl', 'sr', 'th', 'zh'];


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

This PR addresses @andrewharvey 's comment [here](https://github.com/mapbox/mapbox-gl-geocoder/issues/51#issuecomment-474721844) and passes the `options.flyTo` value set in the constructor to the `map.fitBounds` method when a selected feature has a bounding box. 

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
