### PR TITLE
Fix double moveend event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -179,7 +179,7 @@ MapboxGeocoder.prototype = {
   _onChange: function() {
     if (this._inputEl.value) this._clearEl.style.display = 'block';
     var selected = this._typeahead.selected;
-    if (selected) {
+    if (selected  && selected.id !== this.lastSelected) {
       if (this.options.flyTo) {
         if (selected.properties && !exceptions[selected.properties.short_code] && selected.bbox) {
           var bbox = selected.bbox;
@@ -201,11 +201,9 @@ MapboxGeocoder.prototype = {
           this._map.flyTo(flyOptions);
         }
       }
-      if (selected.id !== this.lastSelected){
-        this._eventEmitter.emit('result', { result: selected });
-        this.eventManager.select(selected, this);
-        this.lastSelected =  selected.id;
-      }
+      this._eventEmitter.emit('result', { result: selected });
+      this.eventManager.select(selected, this);
+      this.lastSelected =  selected.id;
     }
   },
 


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Fixes #131 by triggering only one moveend event instead of two. Uses the same logic introduced in #218 to deduplicate `result` events. 

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [n/a] run `npm run docs` and commit changes to API.md
 - [n/a] update CHANGELOG.md with changes under `master` heading before merging
