### PR TITLE
remove bias results around map view example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ See [API.md](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md) fo
  - [Limit geocoder results to a named region](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-limit-region/)
  - [Supplement geocoding search results from another data source](https://www.mapbox.com/mapbox-gl-js/example/forward-geocode-custom-data/)
  - [Accept coordinates as input to a geocoder](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-accept-coordinates/)
- - [Bias geocoder results around the map view](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-proximity-bias/)
 
 ### Contributing
 


### PR DESCRIPTION
This example has become redundant with the introduction of `trackProximity`, especially so now that it's on by default.

closes #247
