### PR TITLE
Add option to blur + clear on esc keypress

### DIFF
--- a/API.md
+++ b/API.md
@@ -71,6 +71,7 @@ A geocoder component using Mapbox Geocoding API
         higher priority.
     -   `options.trackProximity` **[Boolean][56]** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
     -   `options.collapsed` **[Boolean][56]** If true, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
+    -   `options.clearAndBlurOnEsc` **[Boolean][56]** If true, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
     -   `options.bbox` **[Array][57]?** a bounding box argument: this is
         a bounding box given as an array in the format [minX, minY, maxX, maxY].
         Search results will be limited to the bounding box.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Master
+- Add `clearAndBlurOnEsc` option to geocoder
+
 ## v4.0.0
 
 ### Breaking Changes ⚠️
@@ -10,7 +13,7 @@
 - Mapbox events upgraded to v0.2.0 for better handling [#212](https://github.com/mapbox/mapbox-gl-geocoder/pull/212)
 - Pass `flyTo` options to the map on result selection on both map#flyTo and map#fitBounds operations [#214](https://github.com/mapbox/mapbox-gl-geocoder/pull/214)  and [#227](https://github.com/mapbox/mapbox-gl-geocoder/pull/227)
 - Bump `suggestions` dependency to v1.4.x
-- Adds the `marker` constructor option that allows adding the selected result to the map as a [marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker). Adding the marker to the map is now the default behavior. [#219](https://github.com/mapbox/mapbox-gl-geocoder/pull/219). 
+- Adds the `marker` constructor option that allows adding the selected result to the map as a [marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker). Adding the marker to the map is now the default behavior. [#219](https://github.com/mapbox/mapbox-gl-geocoder/pull/219).
 - Add `get` and `set` methods for constructor options [#226](https://github.com/mapbox/mapbox-gl-geocoder/pull/226)
 - Add `collapsed` option to collapse the geocoder controller into a button until hovered or focused [#222](https://github.com/mapbox/mapbox-gl-geocoder/issues/222)
 - Expose `clear` as public method [#115](https://github.com/mapbox/mapbox-gl-geocoder/issues/115)

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,9 +18,9 @@ var geocoderService;
  * @param {Object} options
  * @param {String} options.accessToken Required.
  * @param {String} options.origin Use to set a custom API origin. Defaults to https://api.mapbox.com.
- * @param {Object} [options.mapboxgl] A [mapbox-gl](https://github.com/mapbox/mapbox-gl-js) instance to use when creating [Markers](https://docs.mapbox.com/mapbox-gl-js/api/#marker). Required if `options.marker` is true. 
+ * @param {Object} [options.mapboxgl] A [mapbox-gl](https://github.com/mapbox/mapbox-gl-js) instance to use when creating [Markers](https://docs.mapbox.com/mapbox-gl-js/api/#marker). Required if `options.marker` is true.
  * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
- * @param {Boolean|Object} [options.flyTo] If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the map method to specify a custom animation when a result is selected. 
+ * @param {Boolean|Object} [options.flyTo] If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the map method to specify a custom animation when a result is selected.
  * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
  * @param {Object} [options.proximity] a proximity argument: this is
  * a geographical point given as an object with latitude and longitude
@@ -28,6 +28,7 @@ var geocoderService;
  * higher priority.
  * @param {Boolean} [options.trackProximity=true] If true, the geocoder proximity will automatically update based on the map view.
  * @param {Boolean} [options.collapsed=false] If true, the geocoder control will collapse until hovered or in focus.
+ * @param {Boolean} [options.clearAndBlurOnEsc=false] If true, the geocoder control will clear it's contents and blur when user presses the escape key.
  * @param {Array} [options.bbox] a bounding box argument: this is
  * a bounding box given as an array in the format [minX, minY, maxX, maxY].
  * Search results will be limited to the bounding box.
@@ -45,9 +46,9 @@ var geocoderService;
  * @param {'distance'|'score'} [options.reverseMode='distance'] - Set the factors that are used to sort nearby results.
  * @param {boolean} [options.reverseGeocode] Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
  * @param {Boolean} [options.enableEventLogging=true] Allow Mapbox to collect anonymous usage statistics from the plugin
- * @param {Boolean|Object} [options.marker=true]  If `true`, a [Marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker) will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. 
+ * @param {Boolean|Object} [options.marker=true]  If `true`, a [Marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker) will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set.
  * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. Any html in the returned string will be rendered.
- * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. HTML tags in the output string will not be rendered. 
+ * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. HTML tags in the output string will not be rendered.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -76,6 +77,7 @@ MapboxGeocoder.prototype = {
     marker: true,
     mapboxgl: null,
     collapsed: false,
+    clearAndBlurOnEsc: false,
     getItemValue: function(item) {
       return item.place_name
     },
@@ -116,7 +118,7 @@ MapboxGeocoder.prototype = {
 
     this._inputEl = document.createElement('input');
     this._inputEl.type = 'text';
-    
+
     this.setPlaceholder();
 
     if (this.options.collapsed) {
@@ -206,6 +208,13 @@ MapboxGeocoder.prototype = {
   },
 
   _onKeyDown: function(e) {
+    var ESC_KEY_CODE = 27,
+      TAB_KEY_CODE = 9;
+
+    if (e.keyCode === ESC_KEY_CODE && this.options.clearAndBlurOnEsc) {
+      this.clear(e);
+      return this._inputEl.blur();
+    }
 
     // if target has shadowRoot, then get the actual active element inside the shadowRoot
     var target = e.target && e.target.shadowRoot
@@ -215,12 +224,12 @@ MapboxGeocoder.prototype = {
     if (!value) {
       this.fresh = true;
       // the user has removed all the text
-      if (e.keyCode !== 9) this.clear(e);
+      if (e.keyCode !== TAB_KEY_CODE) this.clear(e);
       return (this._clearEl.style.display = 'none');
     }
 
     // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
-    if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1)
+    if (e.metaKey || [TAB_KEY_CODE, ESC_KEY_CODE, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1)
       return;
 
     if (target.value.length >= this.options.minLength) {
@@ -397,7 +406,7 @@ MapboxGeocoder.prototype = {
   /**
    * Clear the input
    * @param {Event} [ev] the event that triggered the clear, if available
-   * 
+   *
    */
   clear: function(ev) {
     if (ev) ev.preventDefault();
@@ -557,7 +566,7 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Set the zoom level 
+   * Set the zoom level
    * @param {Number} zoom The zoom level that the map should animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
    * @returns {MapboxGeocoder} this
    */
@@ -576,7 +585,7 @@ MapboxGeocoder.prototype = {
 
   /**
    * Set the flyTo options
-   * @param {Object|Boolean} flyTo  If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the flyTo map method to specify a custom animation. 
+   * @param {Object|Boolean} flyTo  If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the flyTo map method to specify a custom animation.
    */
   setFlyTo: function(flyTo){
     this.options.flyTo = flyTo;
@@ -621,16 +630,16 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Get a list of the countries to limit search results to 
+   * Get a list of the countries to limit search results to
    * @returns {String} a comma separated list of countries to limit to, if any
    */
   getCountries: function(){
-    return this.options.countries;    
+    return this.options.countries;
   },
 
   /**
    * Set the countries to limit search results to
-   * @param {String} countries a comma separated list of countries to limit to 
+   * @param {String} countries a comma separated list of countries to limit to
    * @returns {MapboxGeocoder} this
    */
   setCountries: function(countries){
@@ -639,16 +648,16 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Get a list of the types to limit search results to 
-   * @returns {String} a comma separated list of types to limit to 
+   * Get a list of the types to limit search results to
+   * @returns {String} a comma separated list of types to limit to
    */
   getTypes: function(){
-    return this.options.types;    
+    return this.options.types;
   },
 
   /**
    * Set the types to limit search results to
-   * @param {String} countries a comma separated list of types to limit to 
+   * @param {String} countries a comma separated list of types to limit to
    * @returns {MapboxGeocoder} this
    */
   setTypes: function(types){
@@ -685,8 +694,8 @@ MapboxGeocoder.prototype = {
 
   /**
    * Set the limit value for the number of results to display used by the plugin
-   * @param {Number} limit the number of search results to return 
-   * @returns {MapboxGeocoder} 
+   * @param {Number} limit the number of search results to return
+   * @returns {MapboxGeocoder}
    */
   setLimit: function(limit){
     this.options.limit = limit;
@@ -703,12 +712,12 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Set the filter function used by the plugin. 
+   * Set the filter function used by the plugin.
    * @param {Function} filter A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
    * @returns {MapboxGeocoder} this
    */
   setFilter: function(filter){
-    this.options.filter = filter; 
+    this.options.filter = filter;
     return this;
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,6 +2400,12 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+      "dev": true
+    },
     "bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -11248,6 +11254,54 @@
                 "ansi-regex": "^3.0.0"
               }
             }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "tap-color": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tap-color/-/tap-color-1.1.0.tgz",
+      "integrity": "sha512-Qq6wJ/xCn7dqIaAUAfMF0XuRSP7fOu09aCWJCh7SeVIsUjO8D9xrGr5LlvnUMVIwd6giR2PsmVStmTITaQkqyQ==",
+      "dev": true,
+      "requires": {
+        "byline": "^5.0.0",
+        "chalk": "^1.1.3",
+        "duplexer2": "^0.1.4",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "budo debug/index.js --live -- -t brfs ",
     "prepublish": "NODE_ENV=production && mkdir -p dist && browserify --standalone MapboxGeocoder lib/index.js | uglifyjs -c -m > dist/mapbox-gl-geocoder.min.js && cp lib/mapbox-gl-geocoder.css dist/",
-    "test": "browserify -t envify test/index.js test/events.test.js | smokestack -b firefox | tap-status",
+    "test": "browserify -t envify test/index.js test/events.test.js | smokestack -b firefox | tap-status | tap-color",
     "docs": "documentation build lib/index.js --format=md > API.md",
     "pretest": "npm run lint",
     "lint": "eslint lib test",
@@ -50,6 +50,7 @@
     "mapbox-gl": "^0.47.0",
     "sinon": "^7.2.7",
     "smokestack": "^3.3.1",
+    "tap-color": "^1.1.0",
     "tap-status": "^1.0.1",
     "tape": "^4.10.1",
     "uglify-js": "^2.6.4"

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -161,6 +161,48 @@ test('Geocoder#inputControl', function(tt) {
     t.end();
   });
 
+  tt.test('options.clearAndBlurOnEsc=true clears and blurs on escape', function(t) {
+    t.plan(4);
+    setup({
+      clearAndBlurOnEsc: true
+    });
+    var inputEl = container.querySelector('.mapboxgl-ctrl-geocoder input');
+    var focusSpy = sinon.spy(inputEl, 'focus');
+    var blurSpy = sinon.spy(inputEl, 'blur');
+
+    inputEl.focus();
+    t.equal(focusSpy.called, true, 'input is focused');
+
+    geocoder.setInput('testval');
+    t.equal(inputEl.value, 'testval');
+
+    geocoder._onKeyDown(new KeyboardEvent('keydown',{ code: 1, keyCode: 27 }));
+
+    t.equal(inputEl.value, '', 'value is cleared');
+    t.equal(blurSpy.called, true, 'input is blurred');
+
+    t.end();
+  });
+
+  tt.test('options.clearAndBlurOnEsc=false does not clear and blur on escape', function(t) {
+    t.plan(2);
+    setup({
+      clearAndBlurOnEsc: false
+    });
+    var inputEl = container.querySelector('.mapboxgl-ctrl-geocoder input');
+    var focusSpy = sinon.spy(inputEl, 'focus');
+    var blurSpy = sinon.spy(inputEl, 'blur');
+
+    inputEl.focus();
+    t.equal(focusSpy.called, true, 'input is focused');
+
+    geocoder._onKeyDown(new KeyboardEvent('keydown',{ code: 1, keyCode: 27 }));
+
+    t.equal(blurSpy.called, false, 'input is still focused');
+
+    t.end();
+  });
+
   tt.test('options.collapsed=true', function(t) {
     t.plan(1);
     setup({


### PR DESCRIPTION
Adds the option to blur + clear on esc keypress
refs #240

This PR also adds the `tap-color` devDependency for easier to read test reporting.

@scottsfarley93 for review

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
