### PR TITLE
add clearOnBlur option

### DIFF
--- a/API.md
+++ b/API.md
@@ -58,7 +58,7 @@ A geocoder component using Mapbox Geocoding API
 
 ### Parameters
 
--   `options` **[Object][50]** 
+-   `options` **[Object][50]**
     -   `options.accessToken` **[String][51]** Required.
     -   `options.origin` **[String][51]** Use to set a custom API origin. Defaults to [https://api.mapbox.com][52].
     -   `options.mapboxgl` **[Object][50]?** A [mapbox-gl][53] instance to use when creating [Markers][54]. Required if `options.marker` is true.
@@ -72,6 +72,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.trackProximity` **[Boolean][56]** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
     -   `options.collapsed` **[Boolean][56]** If true, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
     -   `options.clearAndBlurOnEsc` **[Boolean][56]** If true, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
+    -   `options.clearOnBlur` **[Boolean][56]** If true, the geocoder control will clear its value when the input plurs. (optional, default `false`)
     -   `options.bbox` **[Array][57]?** a bounding box argument: this is
         a bounding box given as an array in the format [minX, minY, maxX, maxY].
         Search results will be limited to the bounding box.
@@ -104,7 +105,7 @@ Returns **[MapboxGeocoder][61]** `this`
 
 ### clear
 
-Clear the input
+Clear and then focus the input.
 
 #### Parameters
 
@@ -305,7 +306,7 @@ Set the limit value for the number of results to display used by the plugin
 
 -   `limit` **[Number][55]** the number of search results to return
 
-Returns **[MapboxGeocoder][61]** 
+Returns **[MapboxGeocoder][61]**
 
 ### getFilter
 

--- a/API.md
+++ b/API.md
@@ -72,7 +72,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.trackProximity` **[Boolean][56]** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
     -   `options.collapsed` **[Boolean][56]** If true, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
     -   `options.clearAndBlurOnEsc` **[Boolean][56]** If true, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
-    -   `options.clearOnBlur` **[Boolean][56]** If true, the geocoder control will clear its value when the input plurs. (optional, default `false`)
+    -   `options.clearOnBlur` **[Boolean][56]** If true, the geocoder control will clear its value when the input blurs. (optional, default `false`)
     -   `options.bbox` **[Array][57]?** a bounding box argument: this is
         a bounding box given as an array in the format [minX, minY, maxX, maxY].
         Search results will be limited to the bounding box.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 - Add `clearAndBlurOnEsc` option to geocoder
+- Adds `clearOnBlur` option to clear geocoder input on blur.
 
 ## v4.0.0
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ var geocoderService;
  * @param {Boolean} [options.trackProximity=true] If true, the geocoder proximity will automatically update based on the map view.
  * @param {Boolean} [options.collapsed=false] If true, the geocoder control will collapse until hovered or in focus.
  * @param {Boolean} [options.clearAndBlurOnEsc=false] If true, the geocoder control will clear it's contents and blur when user presses the escape key.
+ * @param {Boolean} [options.clearOnBlur=false] If true, the geocoder control will clear its value when the input plurs.
  * @param {Array} [options.bbox] a bounding box argument: this is
  * a bounding box given as an array in the format [minX, minY, maxX, maxY].
  * Search results will be limited to the bounding box.
@@ -78,6 +79,7 @@ MapboxGeocoder.prototype = {
     mapboxgl: null,
     collapsed: false,
     clearAndBlurOnEsc: false,
+    clearOnBlur: false,
     getItemValue: function(item) {
       return item.place_name
     },
@@ -110,6 +112,8 @@ MapboxGeocoder.prototype = {
     this._updateProximity = this._updateProximity.bind(this);
     this._collapse = this._collapse.bind(this);
     this._unCollapse = this._unCollapse.bind(this);
+    this._clear = this._clear.bind(this);
+    this._clearOnBlur = this._clearOnBlur.bind(this);
 
     var el = (this.container = document.createElement('div'));
     el.className = 'mapboxgl-ctrl-geocoder mapboxgl-ctrl';
@@ -120,6 +124,10 @@ MapboxGeocoder.prototype = {
     this._inputEl.type = 'text';
 
     this.setPlaceholder();
+
+    if (this.options.clearOnBlur) {
+      this._inputEl.addEventListener('blur', this._clearOnBlur);
+    }
 
     if (this.options.collapsed) {
       this._collapse();
@@ -278,6 +286,7 @@ MapboxGeocoder.prototype = {
         this._handleMarker(selected);
       }
 
+      this._inputEl.focus();
       this._eventEmitter.emit('result', { result: selected });
       this.eventManager.select(selected, this);
       this.lastSelected = selected.id;
@@ -404,17 +413,17 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Clear the input
+   * Shared logic for clearing input
    * @param {Event} [ev] the event that triggered the clear, if available
+   * @private
    *
    */
-  clear: function(ev) {
+  _clear: function(ev) {
     if (ev) ev.preventDefault();
     this._inputEl.value = '';
     this._typeahead.selected = null;
     this._typeahead.clear();
     this._onChange();
-    this._inputEl.focus();
     this._clearEl.style.display = 'none';
     this._removeMarker();
     this.lastSelected = null;
@@ -422,6 +431,36 @@ MapboxGeocoder.prototype = {
     this.fresh = true;
   },
 
+  /**
+   * Clear and then focus the input.
+   * @param {Event} [ev] the event that triggered the clear, if available
+   *
+   */
+  clear: function(ev) {
+    this._clear(ev);
+    this._inputEl.focus();
+  },
+
+
+  /**
+   * Clear the input, without refocusing it. Used to implement clearOnBlur
+   * constructor option.
+   * @param {Event} [ev] the blur event
+   * @private
+   *
+   */
+  _clearOnBlur: function(ev) {
+    var ctx = this;
+
+    // Use setTimeout to delay execution of this._clear until after
+    // this._onChange completes. Otherwise, input is cleared when user makes a
+    // selection from suggestions dropdown.
+    setTimeout(function() {
+      if (document.activeElement !== ctx._inputEl) {
+        ctx._clear(ev);
+      }
+    }, 0);
+  },
 
   _onQueryResult: function(response) {
     var results = response.body;

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ var geocoderService;
  * @param {Boolean} [options.trackProximity=true] If true, the geocoder proximity will automatically update based on the map view.
  * @param {Boolean} [options.collapsed=false] If true, the geocoder control will collapse until hovered or in focus.
  * @param {Boolean} [options.clearAndBlurOnEsc=false] If true, the geocoder control will clear it's contents and blur when user presses the escape key.
- * @param {Boolean} [options.clearOnBlur=false] If true, the geocoder control will clear its value when the input plurs.
+ * @param {Boolean} [options.clearOnBlur=false] If true, the geocoder control will clear its value when the input blurs.
  * @param {Array} [options.bbox] a bounding box argument: this is
  * a bounding box given as an array in the format [minX, minY, maxX, maxY].
  * Search results will be limited to the bounding box.

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -228,6 +228,46 @@ test('Geocoder#inputControl', function(tt) {
     t.end();
   });
 
+
+  // This test is imperfect, because I cannot get smokestack to call the blur
+  // listener no matter what I do. As a workaround, I'm:
+  // 1. Testing that the option was set correctly.
+  // 2. directly calling _clearOnBlur and asserting that it behaves as expected.
+  tt.test('options.clearOnBlur=true', function(t) {
+    t.plan(5);
+    setup({
+      clearOnBlur: true
+    });
+    t.equal(geocoder.options.clearOnBlur, true);
+
+    var inputEl = container.querySelector('.mapboxgl-ctrl-geocoder input');
+    var focusSpy = sinon.spy(inputEl, 'focus');
+
+    geocoder.setInput('testval');
+    t.equal(inputEl.value, 'testval');
+
+    inputEl.focus();
+
+    // directly call _clearOnBlur();
+    geocoder._clearOnBlur();
+
+    t.equal(inputEl.value, 'testval', 'not yet cleared');
+
+    window.setTimeout(function() {
+      t.equal(focusSpy.calledOnce, true), 'called once, focus should not get re-set on input';
+      t.equal(inputEl.value, '', 'cleared after timeout');
+      t.end();
+    }, 0);
+
+  });
+
+  tt.test('options.clearOnBlur=false by default', function(t) {
+    t.plan(1);
+    setup();
+    t.equal(geocoder.options.clearOnBlur, false);
+    t.end();
+  });
+
   tt.test('options.collapsed=true, hover', function(t) {
     t.plan(1);
     setup({


### PR DESCRIPTION
This option provides a more ephemeral geocoder experience, great for apps where the geocoder is a minor feature. This option works best when combined with flyTo configured with duration:0. Closes #240

Note that I had some difficulting testing this components since `blur` event listeners aren't called when expected in smokestack.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging

@scottsfarley93 for review