### PR TITLE
prepare 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## Master
+## v4.1.0
 
 ### Features / Improvements 🚀
-- Add `clearAndBlurOnEsc` option to geocoder
-- Adds `clearOnBlur` option to clear geocoder input on blur.
+- Add `clearAndBlurOnEsc` option to geocoder [#240](https://github.com/mapbox/mapbox-gl-geocoder/issues/240)
+- Adds `clearOnBlur` option to clear geocoder input on blur [#240](https://github.com/mapbox/mapbox-gl-geocoder/issues/240)
 
 ### Bug Fixes 🐛
 * Fix CSS issue where close button was not being centered [#241](https://github.com/mapbox/mapbox-gl-geocoder/issues/241)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",


### PR DESCRIPTION
version 4.1.0 changes:

### Features / Improvements 🚀
- Add `clearAndBlurOnEsc` option to geocoder [#240](https://github.com/mapbox/mapbox-gl-geocoder/issues/240)
- Adds `clearOnBlur` option to clear geocoder input on blur [#240](https://github.com/mapbox/mapbox-gl-geocoder/issues/240)

### Bug Fixes 🐛
* Fix CSS issue where close button was not being centered [#241](https://github.com/mapbox/mapbox-gl-geocoder/issues/241)
* Namespace all CSS to prevent collisions  [#248](https://github.com/mapbox/mapbox-gl-geocoder/issues/248)
* Fix CSS issue with width on input when `collapsed` enabled [#238](https://github.com/mapbox/mapbox-gl-geocoder/issues/238)

@scottsfarley93 for review