### PR TITLE
Patch event query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Master
+
+### Bug fixes 🐛
+
+- Fix issue where selection events are logged with the incorrect `queryString` value. [#262](https://github.com/mapbox/mapbox-gl-geocoder/pull/262)
+
+
 ## v4.1.0
 
 ### Bug fixes 🐛

--- a/lib/events.js
+++ b/lib/events.js
@@ -171,10 +171,13 @@ MapboxEventManager.prototype = {
       keyboardLocale: this.locale
     }
 
+    // get the text in the search bar
     if (event === "search.select"){
-      payload.queryString = geocoder.inputString
+      payload.queryString = geocoder.inputString;
+    }else if (event != "search.select" && geocoder._inputEl){
+      payload.queryString = geocoder._inputEl;
     }else{
-      payload.queryString = (geocoder._inputEl) ? geocoder._inputEl.value : geocoder.inputString;
+      payload.queryString = geocoder.inputString;
     }
     return payload;
   },

--- a/lib/events.js
+++ b/lib/events.js
@@ -59,7 +59,6 @@ MapboxEventManager.prototype = {
     }
     this.lastSentIndex = resultIndex;
     this.lastSentInput = payload.queryString;
-    console.log(payload);
     if (!payload.queryString) return; // will be rejected
     return this.push(payload)
   },
@@ -154,7 +153,7 @@ MapboxEventManager.prototype = {
     else proximity = [geocoder.options.proximity.longitude, geocoder.options.proximity.latitude];
 
     var zoom = (geocoder._map) ? geocoder._map.getZoom() : null;
-    return {
+    var payload = {
       event: event,
       created: +new Date(),
       sessionIdentifier: this.sessionID,
@@ -168,10 +167,16 @@ MapboxEventManager.prototype = {
       proximity: proximity,
       limit: geocoder.options.limit,
       // routing: search.routing, //todo --> add to plugin
-      queryString:  geocoder.inputString,
       mapZoom: zoom,
       keyboardLocale: this.locale
     }
+
+    if (event === "search.select"){
+      payload.queryString = geocoder.inputString
+    }else{
+      payload.queryString = (geocoder._inputEl) ? geocoder._inputEl.value : geocoder.inputString;
+    }
+    return payload;
   },
 
   /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -59,6 +59,7 @@ MapboxEventManager.prototype = {
     }
     this.lastSentIndex = resultIndex;
     this.lastSentInput = payload.queryString;
+    console.log(payload);
     if (!payload.queryString) return; // will be rejected
     return this.push(payload)
   },
@@ -167,7 +168,7 @@ MapboxEventManager.prototype = {
       proximity: proximity,
       limit: geocoder.options.limit,
       // routing: search.routing, //todo --> add to plugin
-      queryString: (geocoder._inputEl) ? geocoder._inputEl.value : geocoder.inputString,
+      queryString:  geocoder.inputString,
       mapZoom: zoom,
       keyboardLocale: this.locale
     }


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Patches a small bug introduced in #212 [change](https://github.com/mapbox/mapbox-gl-geocoder/pull/212/files#diff-71dcd327d0ca067b490b22d677f81966R170) that causes the queryString to be mis-recorded. 

 - [x] briefly describe the changes in this PR
 - [n/a] write tests for all new functionality
 - [n/a] run `npm run docs` and commit changes to API.md
 - [] update CHANGELOG.md with changes under `master` heading before merging
