### PR TITLE
Update README.md with Promise polyfill requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A geocoder control for [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js) us
 
 https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder/
 
+**If you are supporting older browsers, you will need a Promise polyfill.**
+[es6-promise](https://github.com/stefanpenner/es6-promise) is a good one, if you're uncertain.
+
 ### Usage with a module bundler
 
 This module exports a single class called MapboxGeocoder as its default export,


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
closes #265

document the Promise polyfill requirement for older browsers such as IE11. This stems from mapbox-sdk-js which has the same requirement.

/cc @asheemmamoowala 