### PR TITLE
Render error message (#231) and no results message (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Master
+
+### Features / Improvements 🚀
+
+- Render an error message when a search was unsuccessful (#231)
+- Render an error message when a search returned no results (#232)
+
 ## v4.1.2
 
 ### Bug fixes 🐛

--- a/lib/events.js
+++ b/lib/events.js
@@ -175,7 +175,7 @@ MapboxEventManager.prototype = {
     if (event === "search.select"){
       payload.queryString = geocoder.inputString;
     }else if (event != "search.select" && geocoder._inputEl){
-      payload.queryString = geocoder._inputEl;
+      payload.queryString = geocoder._inputEl.value;
     }else{
       payload.queryString = geocoder.inputString;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,6 @@ var mbxGeocoder = require('@mapbox/mapbox-sdk/services/geocoding');
 var MapboxEventManager = require('./events');
 var localization = require('./localization');
 var subtag = require('subtag');
-var geocoderService;
 
 /**
  * A geocoder component using Mapbox Geocoding API
@@ -94,7 +93,7 @@ MapboxGeocoder.prototype = {
 
     this.setLanguage();
 
-    geocoderService = mbxGeocoder(
+    this.geocoderService = mbxGeocoder(
       MapboxClient({
         accessToken: this.options.accessToken,
         origin: this.options.origin
@@ -355,10 +354,10 @@ MapboxGeocoder.prototype = {
       // use first config type if one, if not default to poi
       config.types ? [config.types[0]] : ["poi"];
       config = extend(config, { query: coords, limit: 1 });
-      request = geocoderService.reverseGeocode(config).send();
+      request = this.geocoderService.reverseGeocode(config).send();
     } else {
       config = extend(config, { query: searchInput });
-      request = geocoderService.forwardGeocode(config).send();
+      request = this.geocoderService.forwardGeocode(config).send();
     }
 
     var localGeocoderRes = [];
@@ -379,6 +378,12 @@ MapboxGeocoder.prototype = {
           res = response.body;
         }
 
+        res.config = config;
+        if (this.fresh){
+          this.eventManager.start(this);
+          this.fresh = false;
+        }
+
         // supplement Mapbox Geocoding API results with locally populated results
         res.features = res.features
           ? localGeocoderRes.concat(res.features)
@@ -391,18 +396,15 @@ MapboxGeocoder.prototype = {
 
         if (res.features.length) {
           this._clearEl.style.display = 'block';
+          this._eventEmitter.emit('results', res);
+          this._typeahead.update(res.features);
         } else {
           this._clearEl.style.display = 'none';
           this._typeahead.selected = null;
+          this._renderNoResults();
+          this._eventEmitter.emit('results', res);
         }
 
-        res.config = config;
-        if (this.fresh){
-          this.eventManager.start(this);
-          this.fresh = false;
-        }
-        this._eventEmitter.emit('results', res);
-        this._typeahead.update(res.features);
       }.bind(this)
     );
 
@@ -411,15 +413,16 @@ MapboxGeocoder.prototype = {
         this._loadingEl.style.display = 'none';
 
         // in the event of an error in the Mapbox Geocoding API still display results from the localGeocoder
-        if (localGeocoderRes.length) {
+        if (localGeocoderRes.length && this.options.localGeocoder) {
           this._clearEl.style.display = 'block';
+          this._typeahead.update(localGeocoderRes);
         } else {
           this._clearEl.style.display = 'none';
           this._typeahead.selected = null;
+          this._renderError();
         }
 
         this._eventEmitter.emit('results', { features: localGeocoderRes });
-        this._typeahead.update(localGeocoderRes);
         this._eventEmitter.emit('error', { error: err });
       }.bind(this)
     );
@@ -517,6 +520,23 @@ MapboxGeocoder.prototype = {
   query: function(searchInput) {
     this._geocode(searchInput).then(this._onQueryResult);
     return this;
+  },
+
+  _renderError: function(){
+    var errorMessage = "<div class='mapbox-gl-geocoder--error'>There was an error reaching the server</div>"
+    this._renderMessage(errorMessage);
+  },
+
+  _renderNoResults: function(){
+    var errorMessage = "<div class='mapbox-gl-geocoder--error mapbox-gl-geocoder--no-results'>No results found</div>";
+    this._renderMessage(errorMessage);
+  },
+
+  _renderMessage: function(msg){
+    this._typeahead.update([]);
+    this._typeahead.selected = null;
+    this._typeahead.clear();
+    this._typeahead.renderError(msg);
   },
 
   /**

--- a/lib/mapbox-gl-geocoder.css
+++ b/lib/mapbox-gl-geocoder.css
@@ -232,4 +232,11 @@
     margin-right: -5px;
   }
 
+  .mapbox-gl-geocoder--error{
+    color: darkgray;
+    padding: 8px;
+    font-size: 16px;
+    text-align: center
+  }
+
 }

--- a/lib/mapbox-gl-geocoder.css
+++ b/lib/mapbox-gl-geocoder.css
@@ -233,8 +233,8 @@
   }
 
   .mapbox-gl-geocoder--error{
-    color: darkgray;
-    padding: 8px;
+    color:#909090;
+    padding: 6px 12px;
     font-size: 16px;
     text-align: center
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@mapbox/mapbox-sdk": "^0.5.0",
     "lodash.debounce": "^4.0.6",
-    "suggestions": "^1.4.0",
+    "suggestions": "^1.6.0",
     "subtag": "^0.5.0",
     "nanoid": "^2.0.1",
     "xtend": "^4.0.1"

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -327,6 +327,5 @@ test('Geocoder#inputControl', function(tt) {
     t.ok(consoleSpy.calledOnce, 'the custom clear method was called');
     t.end();
   });
-
   tt.end();
 });


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
This PR closes #231 and #232 by rendering appropriate error messages when a search fails or returns no results, respectively. It uses an updated version of `suggestions` (v1.6.0) to leverage the newly added `renderError` method. 

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
