### PR TITLE
Add mapbox.places-permanent endpoint mode

### DIFF
--- a/API.md
+++ b/API.md
@@ -94,6 +94,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.marker` **([Boolean][57] \| [Object][51])** If `true`, a [Marker][55] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
     -   `options.render` **[Function][60]?** A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON][61] object  as input and return a string. Any html in the returned string will be rendered.
     -   `options.getItemValue` **[Function][60]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][61] object  as input and return a string. HTML tags in the output string will not be rendered.
+    -   `options.mode` **[String][52]** A string specifying the geocoding endpoint to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license. (optional, default `'mapbox.places'`)
 
 ### Examples
 

--- a/API.md
+++ b/API.md
@@ -94,7 +94,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.marker` **([Boolean][57] \| [Object][51])** If `true`, a [Marker][55] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
     -   `options.render` **[Function][60]?** A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON][61] object  as input and return a string. Any html in the returned string will be rendered.
     -   `options.getItemValue` **[Function][60]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][61] object  as input and return a string. HTML tags in the output string will not be rendered.
-    -   `options.mode` **[String][52]** A string specifying the geocoding endpoint to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license. (optional, default `'mapbox.places'`)
+    -   `options.mode` **[String][52]** A string specifying the geocoding [endpoint][62] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `'mapbox.places'`)
 
 ### Examples
 
@@ -103,7 +103,7 @@ var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
 map.addControl(geocoder);
 ```
 
-Returns **[MapboxGeocoder][62]** `this`
+Returns **[MapboxGeocoder][63]** `this`
 
 ### clear
 
@@ -111,7 +111,7 @@ Clear and then focus the input.
 
 #### Parameters
 
--   `ev` **[Event][63]?** the event that triggered the clear, if available
+-   `ev` **[Event][64]?** the event that triggered the clear, if available
 
 ### query
 
@@ -121,7 +121,7 @@ Set & query the input
 
 -   `searchInput` **[string][52]** location name or other search input
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### setInput
 
@@ -131,7 +131,7 @@ Set input
 
 -   `searchInput` **[string][52]** location name or other search input
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### setProximity
 
@@ -141,7 +141,7 @@ Set proximity
 
 -   `proximity` **[Object][51]** The new options.proximity value. This is a geographical point given as an object with latitude and longitude properties.
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getProximity
 
@@ -157,7 +157,7 @@ Set the render function used in the results dropdown
 
 -   `fn` **[Function][60]** The function to use as a render function. This function accepts a single [Carmen GeoJSON][61] object as input and returns a string.
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getRenderFunction
 
@@ -175,7 +175,7 @@ Look first at the explicitly set options otherwise use the browser's language se
 
 -   `language` **[String][52]** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getLanguage
 
@@ -197,13 +197,13 @@ Set the zoom level
 
 -   `zoom` **[Number][56]** The zoom level that the map should animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getFlyTo
 
 Get the parameters used to fly to the selected response, if any
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### setFlyTo
 
@@ -227,7 +227,7 @@ Set the value of the input element's placeholder
 
 -   `placeholder` **[String][52]** the text to use as the input element's placeholder
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getBbox
 
@@ -243,7 +243,7 @@ Set the bounding box to limit search results to
 
 -   `bbox` **[Array][58]&lt;[Number][56]>** a bounding box given as an array in the format [minX, minY, maxX, maxY].
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getCountries
 
@@ -259,7 +259,7 @@ Set the countries to limit search results to
 
 -   `countries` **[String][52]** a comma separated list of countries to limit to
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getTypes
 
@@ -276,7 +276,7 @@ Set the types to limit search results to
 -   `types`  
 -   `countries` **[String][52]** a comma separated list of types to limit to
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getMinLength
 
@@ -292,7 +292,7 @@ Set the minimum number of characters typed to trigger results used by the plugin
 
 -   `minLength` **[Number][56]** the minimum length in characters
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### getLimit
 
@@ -308,7 +308,7 @@ Set the limit value for the number of results to display used by the plugin
 
 -   `limit` **[Number][56]** the number of search results to return
 
-Returns **[MapboxGeocoder][62]** 
+Returns **[MapboxGeocoder][63]** 
 
 ### getFilter
 
@@ -324,7 +324,7 @@ Set the filter function used by the plugin.
 
 -   `filter` **[Function][60]** A function which accepts a Feature in the [Carmen GeoJSON][61] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ### on
 
@@ -339,7 +339,7 @@ Subscribe to events that happen within the plugin.
     -   **error** `{ error } Error as string`
 -   `fn` **[Function][60]** function that's called when the event is emitted.
 
-Returns **[MapboxGeocoder][62]** this;
+Returns **[MapboxGeocoder][63]** this;
 
 ### off
 
@@ -350,7 +350,7 @@ Remove an event
 -   `type` **[String][52]** Event name.
 -   `fn` **[Function][60]** Function that should unsubscribe to the event emitted.
 
-Returns **[MapboxGeocoder][62]** this
+Returns **[MapboxGeocoder][63]** this
 
 ## relatedTarget
 
@@ -484,6 +484,8 @@ the list. See issue #258 for details on why we can't do that yet.
 
 [61]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
 
-[62]: #mapboxgeocoder
+[62]: https://docs.mapbox.com/api/search/#endpoints
 
-[63]: https://developer.mozilla.org/docs/Web/API/Event
+[63]: #mapboxgeocoder
+
+[64]: https://developer.mozilla.org/docs/Web/API/Event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Features / Improvements 🚀
+
+- Add an option to use the `mapbox.places-permanent` geocoding endpoint (requires an enterprise license). For more details on `mapbox.places-permanent` see https://docs.mapbox.com/api/search/#mapboxplaces-permanent. (#272)
+
 ## v4.2.0
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,7 @@ var subtag = require('subtag');
  * @param {Boolean|Object} [options.marker=true]  If `true`, a [Marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker) will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set.
  * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. Any html in the returned string will be rendered.
  * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. HTML tags in the output string will not be rendered.
+ * @param {String} [options.mode='mapbox.places'] A string specifying the geocoding endpoint to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license. 
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);

--- a/lib/index.js
+++ b/lib/index.js
@@ -319,7 +319,8 @@ MapboxGeocoder.prototype = {
       'countries',
       'types',
       'language',
-      'reverseMode'
+      'reverseMode',
+      'mode'
     ];
     var self = this;
     // Create config object

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ var subtag = require('subtag');
  * @param {Boolean|Object} [options.marker=true]  If `true`, a [Marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker) will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set.
  * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. Any html in the returned string will be rendered.
  * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. HTML tags in the output string will not be rendered.
- * @param {String} [options.mode='mapbox.places'] A string specifying the geocoding endpoint to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license. 
+ * @param {String} [options.mode='mapbox.places'] A string specifying the geocoding [endpoint](https://docs.mapbox.com/api/search/#endpoints) to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. 
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -545,7 +545,7 @@ test('geocoder', function(tt) {
 
 
   tt.test('options.flyTo [true]', function(t){
-    t.plan(3)
+    t.plan(4)
     setup({
       flyTo: true
     });
@@ -557,14 +557,15 @@ test('geocoder', function(tt) {
       once(function() {
         t.ok(mapFlyMethod.calledOnce, "The map flyTo was called when the option was set to true");
         var calledWithArgs = mapFlyMethod.args[0][0];
-        t.deepEqual(calledWithArgs.center, [ -122.47846, 37.819378 ], 'the map is directed to fly to the right place');
+        t.equals(+calledWithArgs.center[0].toFixed(4), +-122.4797165.toFixed(4), 'the map is directed to fly to the right longitude');
+        t.equals(+calledWithArgs.center[1].toFixed(4),  +37.81878675.toFixed(4), 'the map is directed to fly to the right latitude');
         t.deepEqual(calledWithArgs.zoom, 16, 'the map is directed to fly to the right zoom');
       })
     );
   });
 
   tt.test('options.flyTo [object]', function(t){
-    t.plan(4)
+    t.plan(5)
     setup({
       flyTo: {
         speed: 5,
@@ -580,8 +581,8 @@ test('geocoder', function(tt) {
       once(function() {
         t.ok(mapFlyMethod.calledOnce, "The map flyTo was called when the option was set to true");
         var calledWithArgs = mapFlyMethod.args[0][0];
-        t.deepEqual(calledWithArgs.center, [ -122.47846, 37.819378 ], 'the selected result overrides the constructor center option');
-        t.deepEqual(calledWithArgs.zoom, 4, 'the selected result overrides the constructor zoom option');
+        t.equals(+calledWithArgs.center[0].toFixed(4), +-122.4797165.toFixed(4), 'the map is directed to fly to the right longitude');
+        t.equals(+calledWithArgs.center[1].toFixed(4),  +37.81878675.toFixed(4), 'the map is directed to fly to the right latitude');        t.deepEqual(calledWithArgs.zoom, 4, 'the selected result overrides the constructor zoom option');
         t.deepEqual(calledWithArgs.speed, 5, 'speed argument is passed to the flyTo method');
       })
     );


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


- Add an option to use the `mapbox.places-permanent` geocoding endpoint (requires an enterprise license). For more details on `mapbox.places-permanent` see https://docs.mapbox.com/api/search/#mapboxplaces-permanent.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
