### PR TITLE
Allow local geocoder results only without mapbox api call (#164)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,12 @@
 {
   "env": {
     "node": true,
-    "browser": true
+    "browser": true,
+    "es6": true 
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "script"
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/API.md
+++ b/API.md
@@ -95,6 +95,7 @@ A geocoder component using Mapbox Geocoding API
     -   `options.render` **[Function][60]?** A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON][61] object  as input and return a string. Any html in the returned string will be rendered.
     -   `options.getItemValue` **[Function][60]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][61] object  as input and return a string. HTML tags in the output string will not be rendered.
     -   `options.mode` **[String][52]** A string specifying the geocoding [endpoint][62] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `'mapbox.places'`)
+    -   `options.localGeocoderOnly` **[Boolean][57]?** If `true`, indicates that the localGeocoder results should be the only ones returned to the user. If `false`, indicates that the localGeocoder results should be combined with those from the Mapbox API.
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Master
+
+### Features / Improvements 🚀
+
+- Adds a `localGeocoderOnly` mode that allows queries against a `localGeocoder` without making calls to the Mapbox search API. [#275](https://github.com/mapbox/mapbox-gl-geocoder/issues/275).
+
+
+
 ## v4.3.0
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,7 @@ var subtag = require('subtag');
  * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. Any html in the returned string will be rendered.
  * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. HTML tags in the output string will not be rendered.
  * @param {String} [options.mode='mapbox.places'] A string specifying the geocoding [endpoint](https://docs.mapbox.com/api/search/#endpoints) to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. 
+ * @param {Boolean} [options.localGeocoderOnly] If `true`, indicates that the localGeocoder results should be the only ones returned to the user. If `false`, indicates that the localGeocoder results should be combined with those from the Mapbox API. 
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -94,12 +95,14 @@ MapboxGeocoder.prototype = {
 
     this.setLanguage();
 
-    this.geocoderService = mbxGeocoder(
-      MapboxClient({
-        accessToken: this.options.accessToken,
-        origin: this.options.origin
-      })
-    );
+    if (!this.options.localGeocoderOnly){
+      this.geocoderService = mbxGeocoder(
+        MapboxClient({
+          accessToken: this.options.accessToken,
+          origin: this.options.origin
+        })
+      );  
+    }
 
     this.eventManager = new MapboxEventManager(this.options);
 
@@ -341,9 +344,12 @@ MapboxGeocoder.prototype = {
     }, {});
 
     var request;
+    if (this.options.localGeocoderOnly){
+      request = Promise.resolve();
+    }
     // check if searchInput resembles coordinates, and if it does,
     // make the request a reverseGeocode
-    if (
+    else if (
       this.options.reverseGeocode &&
       /(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/.test(searchInput)
     ) {
@@ -358,6 +364,7 @@ MapboxGeocoder.prototype = {
       config = extend(config, { query: coords, limit: 1 });
       request = this.geocoderService.reverseGeocode(config).send();
     } else {
+      console.log("FORWARD")
       config = extend(config, { query: searchInput });
       request = this.geocoderService.forwardGeocode(config).send();
     }
@@ -376,7 +383,12 @@ MapboxGeocoder.prototype = {
 
         var res = {};
 
-        if (response.statusCode == '200') {
+        if (!response){
+          res = {
+            type: 'FeatureCollection',
+            features: []
+          }
+        }else if (response.statusCode == '200') {
           res = response.body;
         }
 
@@ -385,7 +397,6 @@ MapboxGeocoder.prototype = {
           this.eventManager.start(this);
           this.fresh = false;
         }
-
         // supplement Mapbox Geocoding API results with locally populated results
         res.features = res.features
           ? localGeocoderRes.concat(res.features)

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,10 @@ MapboxGeocoder.prototype = {
       );  
     }
 
+    if (this.options.localGeocoderOnly && !this.options.localGeocoder){
+      throw new Error("A localGeocoder function must be specified to use localGeocoderOnly mode")
+    }
+
     this.eventManager = new MapboxEventManager(this.options);
 
     this._onChange = this._onChange.bind(this);
@@ -364,7 +368,6 @@ MapboxGeocoder.prototype = {
       config = extend(config, { query: coords, limit: 1 });
       request = this.geocoderService.reverseGeocode(config).send();
     } else {
-      console.log("FORWARD")
       config = extend(config, { query: searchInput });
       request = this.geocoderService.forwardGeocode(config).send();
     }

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -18,6 +18,7 @@ test('geocoder', function(tt) {
   function setup(opts) {
     opts = opts || {};
     opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
     container = document.createElement('div');
     map = new mapboxgl.Map({ container: container });
     geocoder = new MapboxGeocoder(opts);
@@ -31,7 +32,6 @@ test('geocoder', function(tt) {
     t.equals(geocoder.inputString, '', 'geocoder is initialized with an input string for keeping track of state');
     t.ok(geocoder.eventManager instanceof mapboxEvents, 'the geocoder has a mapbox event manager');
     t.true(geocoder.options.trackProximity, 'sets trackProximity to true by default');
-    t.true(geocoder.options.enableEventLogging, 'anonymous usage statistics are collected by default');
     t.end();
   });
 

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -20,6 +20,7 @@ test('Geocoder#inputControl', function(tt) {
   function setup(opts) {
     opts = opts || {};
     opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
     container = document.createElement('div');
     map = new mapboxgl.Map({ container: container });
     geocoder = new MapboxGeocoder(opts);


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
This PR resolves #164 to create a local geocoder only mode. This mode, entered by setting the new `localGeocoderOnly` key to `true`, will skip calls to the mapbox API and instead use only the localGeocoder.


 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
