### PR TITLE
upgrade mapbox-gl-js peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uglify-js": "^2.6.4"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.47.0"
+    "mapbox-gl": "^0.47.0 <2.0.0"
   },
   "dependencies": {
     "@mapbox/mapbox-sdk": "^0.5.0",


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Closes https://github.com/mapbox/mapbox-gl-geocoder/issues/279 by upgrading the peer dependency of mapbox-gl-js. 

