### PR TITLE
Fix mapbox-gl peerDependencies specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uglify-js": "^2.6.4"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.47.0 <2.0.0"
+    "mapbox-gl": ">= 0.47.0 < 2.0.0"
   },
   "dependencies": {
     "@mapbox/mapbox-sdk": "^0.5.0",


### PR DESCRIPTION
I think the way that the `mapbox-gl` peerDependency was specified in #280 was incorrect, as I am still getting an error during `npm install`:

```sh
$ npm i --save mapbox-gl@latest
npm WARN @mapbox/mapbox-gl-geocoder@4.4.0 requires a peer of mapbox-gl@^0.47.0 but none is installed. You must install peer dependencies yourself.
```

Here is what the `package.json` [docs](https://docs.npmjs.com/files/package.json#peerdependencies) say:

> Thus, if you’ve worked with every 1.x version of the host package, use "^1.0" or "1.x" to express this. If you depend on features introduced in 1.5.2, use ">= 1.5.2 < 2".

This PR changes the `mapbox-gl` peerDependency to match the format described by the above docs. 
