### PR TITLE
No Map

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,56 +5,58 @@
 -   [MapboxGeocoder][1]
     -   [Parameters][2]
     -   [Examples][3]
-    -   [clear][4]
+    -   [addTo][4]
         -   [Parameters][5]
-    -   [query][6]
+    -   [clear][6]
         -   [Parameters][7]
-    -   [setInput][8]
+    -   [query][8]
         -   [Parameters][9]
-    -   [setProximity][10]
+    -   [setInput][10]
         -   [Parameters][11]
-    -   [getProximity][12]
-    -   [setRenderFunction][13]
-        -   [Parameters][14]
-    -   [getRenderFunction][15]
-    -   [setLanguage][16]
-        -   [Parameters][17]
-    -   [getLanguage][18]
-    -   [getZoom][19]
-    -   [setZoom][20]
-        -   [Parameters][21]
-    -   [getFlyTo][22]
-    -   [setFlyTo][23]
-        -   [Parameters][24]
-    -   [getPlaceholder][25]
-    -   [setPlaceholder][26]
-        -   [Parameters][27]
-    -   [getBbox][28]
-    -   [setBbox][29]
-        -   [Parameters][30]
-    -   [getCountries][31]
-    -   [setCountries][32]
-        -   [Parameters][33]
-    -   [getTypes][34]
-    -   [setTypes][35]
-        -   [Parameters][36]
-    -   [getMinLength][37]
-    -   [setMinLength][38]
-        -   [Parameters][39]
-    -   [getLimit][40]
-    -   [setLimit][41]
-        -   [Parameters][42]
-    -   [getFilter][43]
-    -   [setFilter][44]
-        -   [Parameters][45]
-    -   [setOrigin][46]
+    -   [setProximity][12]
+        -   [Parameters][13]
+    -   [getProximity][14]
+    -   [setRenderFunction][15]
+        -   [Parameters][16]
+    -   [getRenderFunction][17]
+    -   [setLanguage][18]
+        -   [Parameters][19]
+    -   [getLanguage][20]
+    -   [getZoom][21]
+    -   [setZoom][22]
+        -   [Parameters][23]
+    -   [getFlyTo][24]
+    -   [setFlyTo][25]
+        -   [Parameters][26]
+    -   [getPlaceholder][27]
+    -   [setPlaceholder][28]
+        -   [Parameters][29]
+    -   [getBbox][30]
+    -   [setBbox][31]
+        -   [Parameters][32]
+    -   [getCountries][33]
+    -   [setCountries][34]
+        -   [Parameters][35]
+    -   [getTypes][36]
+    -   [setTypes][37]
+        -   [Parameters][38]
+    -   [getMinLength][39]
+    -   [setMinLength][40]
+        -   [Parameters][41]
+    -   [getLimit][42]
+    -   [setLimit][43]
+        -   [Parameters][44]
+    -   [getFilter][45]
+    -   [setFilter][46]
         -   [Parameters][47]
-    -   [getOrigin][48]
-    -   [on][49]
-        -   [Parameters][50]
-    -   [off][51]
+    -   [setOrigin][48]
+        -   [Parameters][49]
+    -   [getOrigin][50]
+    -   [on][51]
         -   [Parameters][52]
--   [relatedTarget][53]
+    -   [off][53]
+        -   [Parameters][54]
+-   [relatedTarget][55]
 
 ## MapboxGeocoder
 
@@ -62,43 +64,43 @@ A geocoder component using Mapbox Geocoding API
 
 ### Parameters
 
--   `options` **[Object][54]** 
-    -   `options.accessToken` **[String][55]** Required.
-    -   `options.origin` **[String][55]** Use to set a custom API origin. Defaults to [https://api.mapbox.com][56].
-    -   `options.mapboxgl` **[Object][54]?** A [mapbox-gl][57] instance to use when creating [Markers][58]. Required if `options.marker` is true.
-    -   `options.zoom` **[Number][59]** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
-    -   `options.flyTo` **([Boolean][60] \| [Object][54])?** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the map method to specify a custom animation when a result is selected.
-    -   `options.placeholder` **[String][55]** Override the default placeholder attribute value. (optional, default `"Search"`)
-    -   `options.proximity` **[Object][54]?** a proximity argument: this is
+-   `options` **[Object][56]** 
+    -   `options.accessToken` **[String][57]** Required.
+    -   `options.origin` **[String][57]** Use to set a custom API origin. Defaults to [https://api.mapbox.com][58].
+    -   `options.mapboxgl` **[Object][56]?** A [mapbox-gl][59] instance to use when creating [Markers][60]. Required if `options.marker` is true.
+    -   `options.zoom` **[Number][61]** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
+    -   `options.flyTo` **([Boolean][62] \| [Object][56])?** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the map method to specify a custom animation when a result is selected.
+    -   `options.placeholder` **[String][57]** Override the default placeholder attribute value. (optional, default `"Search"`)
+    -   `options.proximity` **[Object][56]?** a proximity argument: this is
         a geographical point given as an object with latitude and longitude
         properties. Search results closer to this point will be given
         higher priority.
-    -   `options.trackProximity` **[Boolean][60]** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
-    -   `options.collapsed` **[Boolean][60]** If true, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
-    -   `options.clearAndBlurOnEsc` **[Boolean][60]** If true, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
-    -   `options.clearOnBlur` **[Boolean][60]** If true, the geocoder control will clear its value when the input blurs. (optional, default `false`)
-    -   `options.bbox` **[Array][61]?** a bounding box argument: this is
+    -   `options.trackProximity` **[Boolean][62]** If true, the geocoder proximity will automatically update based on the map view. (optional, default `true`)
+    -   `options.collapsed` **[Boolean][62]** If true, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
+    -   `options.clearAndBlurOnEsc` **[Boolean][62]** If true, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
+    -   `options.clearOnBlur` **[Boolean][62]** If true, the geocoder control will clear its value when the input blurs. (optional, default `false`)
+    -   `options.bbox` **[Array][63]?** a bounding box argument: this is
         a bounding box given as an array in the format [minX, minY, maxX, maxY].
         Search results will be limited to the bounding box.
-    -   `options.countries` **[string][55]?** a comma separated list of country codes to
+    -   `options.countries` **[string][57]?** a comma separated list of country codes to
         limit results to specified country or countries.
-    -   `options.types` **[string][55]?** a comma seperated list of types that filter
-        results to match those specified. See [https://docs.mapbox.com/api/search/#data-types][62]
+    -   `options.types` **[string][57]?** a comma seperated list of types that filter
+        results to match those specified. See [https://docs.mapbox.com/api/search/#data-types][64]
         for available types.
         If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used.
-    -   `options.minLength` **[Number][59]** Minimum number of characters to enter before results are shown. (optional, default `2`)
-    -   `options.limit` **[Number][59]** Maximum number of results to show. (optional, default `5`)
-    -   `options.language` **[string][55]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
-    -   `options.filter` **[Function][63]?** A function which accepts a Feature in the [Carmen GeoJSON][64] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
-    -   `options.localGeocoder` **[Function][63]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON][64] format.
+    -   `options.minLength` **[Number][61]** Minimum number of characters to enter before results are shown. (optional, default `2`)
+    -   `options.limit` **[Number][61]** Maximum number of results to show. (optional, default `5`)
+    -   `options.language` **[string][57]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
+    -   `options.filter` **[Function][65]?** A function which accepts a Feature in the [Carmen GeoJSON][66] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+    -   `options.localGeocoder` **[Function][65]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON][66] format.
     -   `options.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
-    -   `options.reverseGeocode` **[boolean][60]?** Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
-    -   `options.enableEventLogging` **[Boolean][60]** Allow Mapbox to collect anonymous usage statistics from the plugin (optional, default `true`)
-    -   `options.marker` **([Boolean][60] \| [Object][54])** If `true`, a [Marker][58] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
-    -   `options.render` **[Function][63]?** A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON][64] object  as input and return a string. Any html in the returned string will be rendered.
-    -   `options.getItemValue` **[Function][63]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][64] object  as input and return a string. HTML tags in the output string will not be rendered.
-    -   `options.mode` **[String][55]** A string specifying the geocoding [endpoint][65] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `'mapbox.places'`)
-    -   `options.localGeocoderOnly` **[Boolean][60]?** If `true`, indicates that the localGeocoder results should be the only ones returned to the user. If `false`, indicates that the localGeocoder results should be combined with those from the Mapbox API.
+    -   `options.reverseGeocode` **[boolean][62]?** Enable reverse geocoding. Defaults to false. Expects coordinates to be lat, lon.
+    -   `options.enableEventLogging` **[Boolean][62]** Allow Mapbox to collect anonymous usage statistics from the plugin (optional, default `true`)
+    -   `options.marker` **([Boolean][62] \| [Object][56])** If `true`, a [Marker][60] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
+    -   `options.render` **[Function][65]?** A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON][66] object  as input and return a string. Any html in the returned string will be rendered.
+    -   `options.getItemValue` **[Function][65]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][66] object  as input and return a string. HTML tags in the output string will not be rendered.
+    -   `options.mode` **[String][57]** A string specifying the geocoding [endpoint][67] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `'mapbox.places'`)
+    -   `options.localGeocoderOnly` **[Boolean][62]?** If `true`, indicates that the localGeocoder results should be the only ones returned to the user. If `false`, indicates that the localGeocoder results should be combined with those from the Mapbox API.
 
 ### Examples
 
@@ -107,7 +109,21 @@ var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
 map.addControl(geocoder);
 ```
 
-Returns **[MapboxGeocoder][66]** `this`
+Returns **[MapboxGeocoder][68]** `this`
+
+### addTo
+
+Add the geocoder to a container. The container can be either a mapboxgl.Map or a reference to an HTML class or ID. 
+
+If the container is a mapboxgl.Map, this function will behave identically to Map.addControl(geocoder)
+If the container is an html id or class, the geocoder will be appended to that element
+
+This function will throw an error if the container is not one a map or a class/id reference
+It will also throw an error if the referenced html element cannot be found in the document.body
+
+#### Parameters
+
+-   `container` **([String][57] | mapboxgl.Map)** A reference to the container to which to add the geocoder
 
 ### clear
 
@@ -115,7 +131,7 @@ Clear and then focus the input.
 
 #### Parameters
 
--   `ev` **[Event][67]?** the event that triggered the clear, if available
+-   `ev` **[Event][69]?** the event that triggered the clear, if available
 
 ### query
 
@@ -123,9 +139,9 @@ Set & query the input
 
 #### Parameters
 
--   `searchInput` **[string][55]** location name or other search input
+-   `searchInput` **[string][57]** location name or other search input
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### setInput
 
@@ -133,9 +149,9 @@ Set input
 
 #### Parameters
 
--   `searchInput` **[string][55]** location name or other search input
+-   `searchInput` **[string][57]** location name or other search input
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### setProximity
 
@@ -143,15 +159,15 @@ Set proximity
 
 #### Parameters
 
--   `proximity` **[Object][54]** The new options.proximity value. This is a geographical point given as an object with latitude and longitude properties.
+-   `proximity` **[Object][56]** The new options.proximity value. This is a geographical point given as an object with latitude and longitude properties.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getProximity
 
 Get proximity
 
-Returns **[Object][54]** The geocoder proximity
+Returns **[Object][56]** The geocoder proximity
 
 ### setRenderFunction
 
@@ -159,15 +175,15 @@ Set the render function used in the results dropdown
 
 #### Parameters
 
--   `fn` **[Function][63]** The function to use as a render function. This function accepts a single [Carmen GeoJSON][64] object as input and returns a string.
+-   `fn` **[Function][65]** The function to use as a render function. This function accepts a single [Carmen GeoJSON][66] object as input and returns a string.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getRenderFunction
 
 Get the function used to render the results dropdown
 
-Returns **[Function][63]** the render function
+Returns **[Function][65]** the render function
 
 ### setLanguage
 
@@ -177,21 +193,21 @@ Look first at the explicitly set options otherwise use the browser's language se
 
 #### Parameters
 
--   `language` **[String][55]** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
+-   `language` **[String][57]** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getLanguage
 
 Get the language to use in UI elements and when making search requests
 
-Returns **[String][55]** The language(s) used by the plugin, if any
+Returns **[String][57]** The language(s) used by the plugin, if any
 
 ### getZoom
 
 Get the zoom level the map will move to when there is no bounding box on the selected result
 
-Returns **[Number][59]** the map zoom
+Returns **[Number][61]** the map zoom
 
 ### setZoom
 
@@ -199,15 +215,15 @@ Set the zoom level
 
 #### Parameters
 
--   `zoom` **[Number][59]** The zoom level that the map should animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
+-   `zoom` **[Number][61]** The zoom level that the map should animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getFlyTo
 
 Get the parameters used to fly to the selected response, if any
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### setFlyTo
 
@@ -215,13 +231,13 @@ Set the flyTo options
 
 #### Parameters
 
--   `flyTo` **([Object][54] \| [Boolean][60])** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the flyTo map method to specify a custom animation.
+-   `flyTo` **([Object][56] \| [Boolean][62])** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, the object will be passed to the flyTo map method to specify a custom animation.
 
 ### getPlaceholder
 
 Get the value of the placeholder string
 
-Returns **[String][55]** The input element's placeholder value
+Returns **[String][57]** The input element's placeholder value
 
 ### setPlaceholder
 
@@ -229,15 +245,15 @@ Set the value of the input element's placeholder
 
 #### Parameters
 
--   `placeholder` **[String][55]** the text to use as the input element's placeholder
+-   `placeholder` **[String][57]** the text to use as the input element's placeholder
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getBbox
 
 Get the bounding box used by the plugin
 
-Returns **[Array][61]&lt;[Number][59]>** the bounding box, if any
+Returns **[Array][63]&lt;[Number][61]>** the bounding box, if any
 
 ### setBbox
 
@@ -245,15 +261,15 @@ Set the bounding box to limit search results to
 
 #### Parameters
 
--   `bbox` **[Array][61]&lt;[Number][59]>** a bounding box given as an array in the format [minX, minY, maxX, maxY].
+-   `bbox` **[Array][63]&lt;[Number][61]>** a bounding box given as an array in the format [minX, minY, maxX, maxY].
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getCountries
 
 Get a list of the countries to limit search results to
 
-Returns **[String][55]** a comma separated list of countries to limit to, if any
+Returns **[String][57]** a comma separated list of countries to limit to, if any
 
 ### setCountries
 
@@ -261,15 +277,15 @@ Set the countries to limit search results to
 
 #### Parameters
 
--   `countries` **[String][55]** a comma separated list of countries to limit to
+-   `countries` **[String][57]** a comma separated list of countries to limit to
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getTypes
 
 Get a list of the types to limit search results to
 
-Returns **[String][55]** a comma separated list of types to limit to
+Returns **[String][57]** a comma separated list of types to limit to
 
 ### setTypes
 
@@ -278,15 +294,15 @@ Set the types to limit search results to
 #### Parameters
 
 -   `types`  
--   `countries` **[String][55]** a comma separated list of types to limit to
+-   `countries` **[String][57]** a comma separated list of types to limit to
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getMinLength
 
 Get the minimum number of characters typed to trigger results used in the plugin
 
-Returns **[Number][59]** The minimum length in characters before a search is triggered
+Returns **[Number][61]** The minimum length in characters before a search is triggered
 
 ### setMinLength
 
@@ -294,15 +310,15 @@ Set the minimum number of characters typed to trigger results used by the plugin
 
 #### Parameters
 
--   `minLength` **[Number][59]** the minimum length in characters
+-   `minLength` **[Number][61]** the minimum length in characters
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getLimit
 
 Get the limit value for the number of results to display used by the plugin
 
-Returns **[Number][59]** The limit value for the number of results to display used by the plugin
+Returns **[Number][61]** The limit value for the number of results to display used by the plugin
 
 ### setLimit
 
@@ -310,15 +326,15 @@ Set the limit value for the number of results to display used by the plugin
 
 #### Parameters
 
--   `limit` **[Number][59]** the number of search results to return
+-   `limit` **[Number][61]** the number of search results to return
 
-Returns **[MapboxGeocoder][66]** 
+Returns **[MapboxGeocoder][68]** 
 
 ### getFilter
 
 Get the filter function used by the plugin
 
-Returns **[Function][63]** the filter function
+Returns **[Function][65]** the filter function
 
 ### setFilter
 
@@ -326,9 +342,9 @@ Set the filter function used by the plugin.
 
 #### Parameters
 
--   `filter` **[Function][63]** A function which accepts a Feature in the [Carmen GeoJSON][64] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+-   `filter` **[Function][65]** A function which accepts a Feature in the [Carmen GeoJSON][66] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### setOrigin
 
@@ -336,15 +352,15 @@ Set the geocoding endpoint used by the plugin.
 
 #### Parameters
 
--   `origin` **[Function][63]** A function which accepts an HTTPS URL to specify the endpoint to query results from.
+-   `origin` **[Function][65]** A function which accepts an HTTPS URL to specify the endpoint to query results from.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ### getOrigin
 
 Get the geocoding endpoint the plugin is currently set to
 
-Returns **[Function][63]** the endpoint URL
+Returns **[Function][65]** the endpoint URL
 
 ### on
 
@@ -352,14 +368,14 @@ Subscribe to events that happen within the plugin.
 
 #### Parameters
 
--   `type` **[String][55]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
+-   `type` **[String][57]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
     -   **loading** `{ query } Emitted when the geocoder is looking up a query`
     -   **results** `{ results } Fired when the geocoder returns a response`
     -   **result** `{ result } Fired when input is set`
     -   **error** `{ error } Error as string`
--   `fn` **[Function][63]** function that's called when the event is emitted.
+-   `fn` **[Function][65]** function that's called when the event is emitted.
 
-Returns **[MapboxGeocoder][66]** this;
+Returns **[MapboxGeocoder][68]** this;
 
 ### off
 
@@ -367,10 +383,10 @@ Remove an event
 
 #### Parameters
 
--   `type` **[String][55]** Event name.
--   `fn` **[Function][63]** Function that should unsubscribe to the event emitted.
+-   `type` **[String][57]** Event name.
+-   `fn` **[Function][65]** Function that should unsubscribe to the event emitted.
 
-Returns **[MapboxGeocoder][66]** this
+Returns **[MapboxGeocoder][68]** this
 
 ## relatedTarget
 
@@ -388,130 +404,134 @@ the list. See issue #258 for details on why we can't do that yet.
 
 [3]: #examples
 
-[4]: #clear
+[4]: #addto
 
 [5]: #parameters-1
 
-[6]: #query
+[6]: #clear
 
 [7]: #parameters-2
 
-[8]: #setinput
+[8]: #query
 
 [9]: #parameters-3
 
-[10]: #setproximity
+[10]: #setinput
 
 [11]: #parameters-4
 
-[12]: #getproximity
+[12]: #setproximity
 
-[13]: #setrenderfunction
+[13]: #parameters-5
 
-[14]: #parameters-5
+[14]: #getproximity
 
-[15]: #getrenderfunction
+[15]: #setrenderfunction
 
-[16]: #setlanguage
+[16]: #parameters-6
 
-[17]: #parameters-6
+[17]: #getrenderfunction
 
-[18]: #getlanguage
+[18]: #setlanguage
 
-[19]: #getzoom
+[19]: #parameters-7
 
-[20]: #setzoom
+[20]: #getlanguage
 
-[21]: #parameters-7
+[21]: #getzoom
 
-[22]: #getflyto
+[22]: #setzoom
 
-[23]: #setflyto
+[23]: #parameters-8
 
-[24]: #parameters-8
+[24]: #getflyto
 
-[25]: #getplaceholder
+[25]: #setflyto
 
-[26]: #setplaceholder
+[26]: #parameters-9
 
-[27]: #parameters-9
+[27]: #getplaceholder
 
-[28]: #getbbox
+[28]: #setplaceholder
 
-[29]: #setbbox
+[29]: #parameters-10
 
-[30]: #parameters-10
+[30]: #getbbox
 
-[31]: #getcountries
+[31]: #setbbox
 
-[32]: #setcountries
+[32]: #parameters-11
 
-[33]: #parameters-11
+[33]: #getcountries
 
-[34]: #gettypes
+[34]: #setcountries
 
-[35]: #settypes
+[35]: #parameters-12
 
-[36]: #parameters-12
+[36]: #gettypes
 
-[37]: #getminlength
+[37]: #settypes
 
-[38]: #setminlength
+[38]: #parameters-13
 
-[39]: #parameters-13
+[39]: #getminlength
 
-[40]: #getlimit
+[40]: #setminlength
 
-[41]: #setlimit
+[41]: #parameters-14
 
-[42]: #parameters-14
+[42]: #getlimit
 
-[43]: #getfilter
+[43]: #setlimit
 
-[44]: #setfilter
+[44]: #parameters-15
 
-[45]: #parameters-15
+[45]: #getfilter
 
-[46]: #setorigin
+[46]: #setfilter
 
 [47]: #parameters-16
 
-[48]: #getorigin
+[48]: #setorigin
 
-[49]: #on
+[49]: #parameters-17
 
-[50]: #parameters-17
+[50]: #getorigin
 
-[51]: #off
+[51]: #on
 
 [52]: #parameters-18
 
-[53]: #relatedtarget
+[53]: #off
 
-[54]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[54]: #parameters-19
 
-[55]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[55]: #relatedtarget
 
-[56]: https://api.mapbox.com
+[56]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[57]: https://github.com/mapbox/mapbox-gl-js
+[57]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[58]: https://docs.mapbox.com/mapbox-gl-js/api/#marker
+[58]: https://api.mapbox.com
 
-[59]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[59]: https://github.com/mapbox/mapbox-gl-js
 
-[60]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[60]: https://docs.mapbox.com/mapbox-gl-js/api/#marker
 
-[61]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[61]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[62]: https://docs.mapbox.com/api/search/#data-types
+[62]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[63]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[63]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[64]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+[64]: https://docs.mapbox.com/api/search/#data-types
 
-[65]: https://docs.mapbox.com/api/search/#endpoints
+[65]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[66]: #mapboxgeocoder
+[66]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
 
-[67]: https://developer.mozilla.org/docs/Web/API/Event
+[67]: https://docs.mapbox.com/api/search/#endpoints
+
+[68]: #mapboxgeocoder
+
+[69]: https://developer.mozilla.org/docs/Web/API/Event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+### Features / Improvements 🚀
+
+- Supports adding a geocoder to an arbitrary HTML element so it can be used without a map [#270](https://github.com/mapbox/mapbox-gl-geocoder/issues/270). 
+
+
 ## v4.4.2
 
 ### Features / Improvements 🚀

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ so in browserify or webpack, you can require it like:
 var MapboxGeocoder = require('@mapbox/mapbox-gl-geocoder');
 ```
 
+###  Using without a Map
+It is possible to use the plugin without it being placed as a control on a mapbox-gl map. Keep in mind that the Mapbox [Terms of Service](https://www.mapbox.com/legal/tos#[GAGA]) require that POI search results be shown on a Mapbox map. If you don't need a POIs, you can exclude them from your search results with the `options.types` parameter  when constructing a new Geocoder. 
+
 ### Deeper dive
 
 #### API Documentation

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var MapboxGeocoder = require('@mapbox/mapbox-gl-geocoder');
 ```
 
 ###  Using without a Map
-It is possible to use the plugin without it being placed as a control on a mapbox-gl map. Keep in mind that the Mapbox [Terms of Service](https://www.mapbox.com/legal/tos#[GAGA]) require that POI search results be shown on a Mapbox map. If you don't need a POIs, you can exclude them from your search results with the `options.types` parameter  when constructing a new Geocoder. 
+It is possible to use the plugin without it being placed as a control on a mapbox-gl map. Keep in mind that the Mapbox [Terms of Service](https://www.mapbox.com/legal/tos#[GAGA]) require that POI search results be shown on a Mapbox map. If you don't need POIs, you can exclude them from your search results with the `options.types` parameter  when constructing a new Geocoder. 
 
 ### Deeper dive
 

--- a/debug/index.js
+++ b/debug/index.js
@@ -18,12 +18,12 @@ insertCss(
 
 var MapboxGeocoder = require('../');
 
-// var mapDiv = document.body.appendChild(document.createElement('div'));
-// mapDiv.style.position = 'absolute';
-// mapDiv.style.top = 0;
-// mapDiv.style.right = 0;
-// mapDiv.style.left = 0;
-// mapDiv.style.bottom = 0;
+var mapDiv = document.body.appendChild(document.createElement('div'));
+mapDiv.style.position = 'absolute';
+mapDiv.style.top = 0;
+mapDiv.style.right = 0;
+mapDiv.style.left = 0;
+mapDiv.style.bottom = 0;
 
 var notMapDiv = document.body.appendChild(document.createElement('div'));
 notMapDiv.style.position = 'absolute';
@@ -35,12 +35,12 @@ notMapDiv.style.backgroundColor = 'red';
 
 notMapDiv.classList.add("notAMap");
 
-// var map = new mapboxgl.Map({
-//   container: mapDiv,
-//   style: 'mapbox://styles/mapbox/streets-v9',
-//   center: [-79.4512, 43.6568],
-//   zoom: 13
-// });
+var map = new mapboxgl.Map({
+  container: mapDiv,
+  style: 'mapbox://styles/mapbox/streets-v9',
+  center: [-79.4512, 43.6568],
+  zoom: 13
+});
 
 var coordinatesGeocoder = function(query) {
   var matches = query.match(/^[ ]*(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/);
@@ -97,27 +97,27 @@ window.geocoder = geocoder;
 var button = document.createElement('button');
 button.textContent = 'click me';
 
-// var removeBtn = document.body.appendChild(document.createElement('button'));
-// removeBtn.style.position = 'absolute';
-// removeBtn.style.zIndex = 10;
-// removeBtn.style.top = '10px';
-// removeBtn.style.left = '10px';
-// removeBtn.textContent = 'Remove geocoder control';
+var removeBtn = document.body.appendChild(document.createElement('button'));
+removeBtn.style.position = 'absolute';
+removeBtn.style.zIndex = 10;
+removeBtn.style.top = '10px';
+removeBtn.style.left = '10px';
+removeBtn.textContent = 'Remove geocoder control';
 
-// map
-//   .getContainer()
-//   .querySelector('.mapboxgl-ctrl-bottom-left')
-//   .appendChild(button);
-// // map.addControl(geocoder);
+map
+  .getContainer()
+  .querySelector('.mapboxgl-ctrl-bottom-left')
+  .appendChild(button);
+// map.addControl(geocoder);
 
-// map.on('load', function() {
-//   button.addEventListener('click', function() {
-//     geocoder.query('Montreal Quebec');
-//   });
-//   removeBtn.addEventListener('click', function() {
-//     map.removeControl(geocoder);
-//   });
-// });
+map.on('load', function() {
+  button.addEventListener('click', function() {
+    geocoder.query('Montreal Quebec');
+  });
+  removeBtn.addEventListener('click', function() {
+    map.removeControl(geocoder);
+  });
+});
 
 geocoder.on('results', function(e) {
   console.log('results: ', e.features);

--- a/debug/index.js
+++ b/debug/index.js
@@ -25,16 +25,6 @@ mapDiv.style.right = 0;
 mapDiv.style.left = 0;
 mapDiv.style.bottom = 0;
 
-var notMapDiv = document.body.appendChild(document.createElement('div'));
-notMapDiv.style.position = 'absolute';
-notMapDiv.style.top = 0;
-notMapDiv.style.right = 0;
-notMapDiv.style.left = 0;
-notMapDiv.style.bottom = 0;
-notMapDiv.style.backgroundColor = 'red';
-
-notMapDiv.classList.add("notAMap");
-
 var map = new mapboxgl.Map({
   container: mapDiv,
   style: 'mapbox://styles/mapbox/streets-v9',
@@ -90,7 +80,7 @@ var geocoder = new MapboxGeocoder({
   mapboxgl: mapboxgl
 });
 
-geocoder.addTo('.notAMap')
+map.addControl(geocoder)
 
 window.geocoder = geocoder;
 
@@ -108,7 +98,6 @@ map
   .getContainer()
   .querySelector('.mapboxgl-ctrl-bottom-left')
   .appendChild(button);
-// map.addControl(geocoder);
 
 map.on('load', function() {
   button.addEventListener('click', function() {

--- a/debug/index.js
+++ b/debug/index.js
@@ -18,19 +18,29 @@ insertCss(
 
 var MapboxGeocoder = require('../');
 
-var mapDiv = document.body.appendChild(document.createElement('div'));
-mapDiv.style.position = 'absolute';
-mapDiv.style.top = 0;
-mapDiv.style.right = 0;
-mapDiv.style.left = 0;
-mapDiv.style.bottom = 0;
+// var mapDiv = document.body.appendChild(document.createElement('div'));
+// mapDiv.style.position = 'absolute';
+// mapDiv.style.top = 0;
+// mapDiv.style.right = 0;
+// mapDiv.style.left = 0;
+// mapDiv.style.bottom = 0;
 
-var map = new mapboxgl.Map({
-  container: mapDiv,
-  style: 'mapbox://styles/mapbox/streets-v9',
-  center: [-79.4512, 43.6568],
-  zoom: 13
-});
+var notMapDiv = document.body.appendChild(document.createElement('div'));
+notMapDiv.style.position = 'absolute';
+notMapDiv.style.top = 0;
+notMapDiv.style.right = 0;
+notMapDiv.style.left = 0;
+notMapDiv.style.bottom = 0;
+notMapDiv.style.backgroundColor = 'red';
+
+notMapDiv.classList.add("notAMap");
+
+// var map = new mapboxgl.Map({
+//   container: mapDiv,
+//   style: 'mapbox://styles/mapbox/streets-v9',
+//   center: [-79.4512, 43.6568],
+//   zoom: 13
+// });
 
 var coordinatesGeocoder = function(query) {
   var matches = query.match(/^[ ]*(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/);
@@ -80,32 +90,34 @@ var geocoder = new MapboxGeocoder({
   mapboxgl: mapboxgl
 });
 
+geocoder.addTo('.notAMap')
+
 window.geocoder = geocoder;
 
 var button = document.createElement('button');
 button.textContent = 'click me';
 
-var removeBtn = document.body.appendChild(document.createElement('button'));
-removeBtn.style.position = 'absolute';
-removeBtn.style.zIndex = 10;
-removeBtn.style.top = '10px';
-removeBtn.style.left = '10px';
-removeBtn.textContent = 'Remove geocoder control';
+// var removeBtn = document.body.appendChild(document.createElement('button'));
+// removeBtn.style.position = 'absolute';
+// removeBtn.style.zIndex = 10;
+// removeBtn.style.top = '10px';
+// removeBtn.style.left = '10px';
+// removeBtn.textContent = 'Remove geocoder control';
 
-map
-  .getContainer()
-  .querySelector('.mapboxgl-ctrl-bottom-left')
-  .appendChild(button);
-map.addControl(geocoder);
+// map
+//   .getContainer()
+//   .querySelector('.mapboxgl-ctrl-bottom-left')
+//   .appendChild(button);
+// // map.addControl(geocoder);
 
-map.on('load', function() {
-  button.addEventListener('click', function() {
-    geocoder.query('Montreal Quebec');
-  });
-  removeBtn.addEventListener('click', function() {
-    map.removeControl(geocoder);
-  });
-});
+// map.on('load', function() {
+//   button.addEventListener('click', function() {
+//     geocoder.query('Montreal Quebec');
+//   });
+//   removeBtn.addEventListener('click', function() {
+//     map.removeControl(geocoder);
+//   });
+// });
 
 geocoder.on('results', function(e) {
   console.log('results: ', e.features);
@@ -116,6 +128,7 @@ geocoder.on('result', function(e) {
 });
 
 geocoder.on('clear', function(e) {
+  console.log(e)
   console.log('clear');
 });
 

--- a/debug/nomap.js
+++ b/debug/nomap.js
@@ -1,0 +1,60 @@
+'use strict';
+var mapboxgl = require('mapbox-gl');
+var insertCss = require('insert-css');
+var fs = require('fs');
+
+mapboxgl.accessToken = window.localStorage.getItem('MapboxAccessToken');
+
+
+var meta = document.createElement('meta');
+meta.name = 'viewport';
+meta.content = 'initial-scale=1,maximum-scale=1,user-scalable=no';
+document.getElementsByTagName('head')[0].appendChild(meta);
+
+insertCss(fs.readFileSync('./lib/mapbox-gl-geocoder.css', 'utf8'));
+insertCss(
+  fs.readFileSync('./node_modules/mapbox-gl/dist/mapbox-gl.css', 'utf8')
+);
+
+var MapboxGeocoder = require('../');
+
+var notMapDiv = document.body.appendChild(document.createElement('div'));
+notMapDiv.style.position = 'absolute';
+notMapDiv.style.top = 0;
+notMapDiv.style.right = 0;
+notMapDiv.style.left = 0;
+notMapDiv.style.bottom = 0;
+notMapDiv.style.backgroundColor = 'darkcyan';
+
+notMapDiv.classList.add("notAMap");
+
+var geocoder = new MapboxGeocoder({
+  accessToken: mapboxgl.accessToken,
+  trackProximity: true
+});
+
+geocoder.addTo('.notAMap')
+
+window.geocoder = geocoder;
+
+
+geocoder.on('results', function(e) {
+  console.log('results: ', e.features);
+});
+
+geocoder.on('result', function(e) {
+  console.log('result: ', e.result);
+});
+
+geocoder.on('clear', function(e) {
+  console.log(e)
+  console.log('clear');
+});
+
+geocoder.on('loading', function(e) {
+  console.log('loading:', e.query);
+});
+
+geocoder.on('error', function(e) {
+  console.log('Error is', e.error);
+});

--- a/lib/events.js
+++ b/lib/events.js
@@ -93,8 +93,6 @@ MapboxEventManager.prototype = {
     if (keyEvent.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(keyEvent.keyCode) !== -1) return;
     var payload = this.getEventPayload('search.keystroke', geocoder);
     payload.lastAction = keyEvent.key;
-    console.log("action: ", payload.lastAction)
-    console.log(payload)
     if (!payload.queryString) return; // will be rejected
     return this.push(payload);
   },

--- a/lib/events.js
+++ b/lib/events.js
@@ -85,6 +85,7 @@ MapboxEventManager.prototype = {
    * 
    */
   keyevent: function(keyEvent, geocoder){
+
     //pass invalid event
     if (!keyEvent.key) return;
     // don't send events for keys that don't change the input
@@ -92,6 +93,8 @@ MapboxEventManager.prototype = {
     if (keyEvent.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(keyEvent.keyCode) !== -1) return;
     var payload = this.getEventPayload('search.keystroke', geocoder);
     payload.lastAction = keyEvent.key;
+    console.log("action: ", payload.lastAction)
+    console.log(payload)
     if (!payload.queryString) return; // will be rejected
     return this.push(payload);
   },
@@ -152,7 +155,7 @@ MapboxEventManager.prototype = {
     if (!geocoder.options.proximity) proximity = null;
     else proximity = [geocoder.options.proximity.longitude, geocoder.options.proximity.latitude];
 
-    var zoom = (geocoder._map) ? geocoder._map.getZoom() : null;
+    var zoom = (geocoder._map) ? geocoder._map.getZoom() : undefined;
     var payload = {
       event: event,
       created: +new Date(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ MapboxGeocoder.prototype = {
    * It will also throw an error if the referenced html element cannot be found in the document.body
    * @param {String|mapboxgl.Map} container A reference to the container to which to add the geocoder 
    */
-  addTo(container){
+  addTo: function(container){
     // if the container is a map, add the control like normal
     if (container._controlContainer){
       //  it's a mapbox-gl map, add like normal 
@@ -110,10 +110,10 @@ MapboxGeocoder.prototype = {
     else if (typeof container == 'string' && (container.startsWith('#') || container.startsWith('.'))){
       const parent = document.querySelectorAll(container);
       if (parent.length == 0){
-        throw new Error(`Element ${container} not found.`)
+        throw new Error("Element ", container, "not found.")
       }
       
-      parent.forEach((parentEl)=>{
+      parent.forEach(function(parentEl){
         const el = this.onAdd(); //no map
         parentEl.appendChild(el);
       })

--- a/lib/index.js
+++ b/lib/index.js
@@ -221,14 +221,13 @@ MapboxGeocoder.prototype = {
     this.setRenderFunction(this.options.render);
     this._typeahead.getItemValue = this.options.getItemValue;
 
-    if (this.options.trackProximity && this._map) {
-      this._updateProximity();
-      this._map.on('moveend', this._updateProximity);
-    }
-
     this.mapMarker = null;
     this._handleMarker = this._handleMarker.bind(this);
     if (this._map){
+      if (this.options.trackProximity ) {
+        this._updateProximity();
+        this._map.on('moveend', this._updateProximity);
+      }
       this._mapboxgl = this.options.mapboxgl;
       if (!this._mapboxgl && this.options.marker) {
        // eslint-disable-next-line no-console

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,16 @@ MapboxGeocoder.prototype = {
     }
   },
 
+  /**
+   * Add the geocoder to a container. The container can be either a mapboxgl.Map or a reference to an HTML class or ID. 
+   * 
+   * If the container is a mapboxgl.Map, this function will behave identically to Map.addControl(geocoder)
+   * If the container is an html id or class, the geocoder will be appended to that element
+   * 
+   * This function will throw an error if the container is not one a map or a class/id reference
+   * It will also throw an error if the referenced html element cannot be found in the document.body
+   * @param {String|mapboxgl.Map} container A reference to the container to which to add the geocoder 
+   */
   addTo(container){
     // if the container is a map, add the control like normal
     if (container._controlContainer){

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,8 +113,12 @@ MapboxGeocoder.prototype = {
         throw new Error("Element ", container, "not found.")
       }
 
+      if (parent.length > 1){
+        throw new Error("Geocoder can only be added to a single html element")
+      }
+
       parent.forEach(function(parentEl){
-        const el = this.onAdd(); //no map
+        const el = this.onAdd(); //returns the input elements, which are then added to the requested html container
         parentEl.appendChild(el);
       }.bind(this))
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -231,6 +231,7 @@ MapboxGeocoder.prototype = {
     if (this._map){
       this._mapboxgl = this.options.mapboxgl;
       if (!this._mapboxgl && this.options.marker) {
+       // eslint-disable-next-line no-console
         console.error("No mapboxgl detected in options. Map markers are disabled. Please set options.mapboxgl.");
         this.options.marker = false;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,8 +90,32 @@ MapboxGeocoder.prototype = {
     }
   },
 
+  addTo(container){
+    // if the container is a map, add the control like normal
+    if (container._controlContainer){
+      //  it's a mapbox-gl map, add like normal 
+      container.addControl(this)
+    }
+    // if the container is not a map, but an html element, then add the control to that element
+    else if (typeof container == 'string' && (container.startsWith('#') || container.startsWith('.'))){
+      const parent = document.querySelectorAll(container);
+      if (parent.length == 0){
+        throw new Error(`Element ${container} not found.`)
+      }
+      parent.forEach((parentEl)=>{
+        const el = this.onAdd(); //no map
+        parentEl.appendChild(el);
+      })
+
+    }else{
+      throw new Error("Error: addTo Container must be a mapbox-gl-js map or a html element reference")
+    }
+  },
+
   onAdd: function(map) {
-    this._map = map;
+    if (map && typeof map != 'string'){
+      this._map = map;
+    }
 
     this.setLanguage();
 
@@ -182,20 +206,20 @@ MapboxGeocoder.prototype = {
     this.setRenderFunction(this.options.render);
     this._typeahead.getItemValue = this.options.getItemValue;
 
-    if (this.options.trackProximity) {
+    if (this.options.trackProximity && this._map) {
       this._updateProximity();
       this._map.on('moveend', this._updateProximity);
     }
 
     this.mapMarker = null;
     this._handleMarker = this._handleMarker.bind(this);
-
-    this._mapboxgl = this.options.mapboxgl;
-    if (!this._mapboxgl && this.options.marker) {
-      console.error("No mapboxgl detected in options. Map markers are disabled. Please set options.mapboxgl.");
-      this.options.marker = false;
+    if (this._map){
+      this._mapboxgl = this.options.mapboxgl;
+      if (!this._mapboxgl && this.options.marker) {
+        console.error("No mapboxgl detected in options. Map markers are disabled. Please set options.mapboxgl.");
+        this.options.marker = false;
+      }
     }
-
     return el;
   },
 
@@ -213,7 +237,7 @@ MapboxGeocoder.prototype = {
   onRemove: function() {
     this.container.parentNode.removeChild(this.container);
 
-    if (this.options.trackProximity) {
+    if (this.options.trackProximity && this._map) {
       this._map.off('moveend', this._updateProximity);
     }
 
@@ -279,7 +303,9 @@ MapboxGeocoder.prototype = {
         if (selected.properties && !exceptions[selected.properties.short_code] && selected.bbox) {
           var bbox = selected.bbox;
           flyOptions = extend({}, this.options.flyTo);
-          this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
+          if (this._map){
+            this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
+          }
         } else if (selected.properties && exceptions[selected.properties.short_code]) {
           // Certain geocoder search results return (and therefore zoom to fit)
           // an unexpectedly large bounding box: for example, both Russia and the
@@ -288,7 +314,9 @@ MapboxGeocoder.prototype = {
           // at ./exceptions.json provides "reasonable" bounding boxes as a
           // short-term solution; this may be amended as necessary.
           flyOptions = extend({}, this.options.flyTo);
-          this._map.fitBounds(exceptions[selected.properties.short_code].bbox, flyOptions);
+          if (this._map){
+            this._map.fitBounds(exceptions[selected.properties.short_code].bbox, flyOptions);
+          }
         } else {
           var defaultFlyOptions = {
             zoom: this.options.zoom
@@ -296,7 +324,9 @@ MapboxGeocoder.prototype = {
           flyOptions = extend({}, defaultFlyOptions, this.options.flyTo);
           //  ensure that center is not overriden by custom options
           flyOptions.center = selected.center;
-          this._map.flyTo(flyOptions);
+          if (this._map){
+            this._map.flyTo(flyOptions);
+          }
         }
       }
       if (this.options.marker && this._mapboxgl){
@@ -513,6 +543,9 @@ MapboxGeocoder.prototype = {
   _updateProximity: function() {
     // proximity is designed for local scale, if the user is looking at the whole world,
     // it doesn't make sense to factor in the arbitrary centre of the map
+    if (!this._map){
+      return;
+    }
     if (this._map.getZoom() > 9) {
       var center = this._map.getCenter().wrap();
       this.setProximity({ longitude: center.lng, latitude: center.lat });
@@ -848,6 +881,9 @@ MapboxGeocoder.prototype = {
    */
   _handleMarker: function(selected){
     // clean up any old marker that might be present
+    if (!this._map){
+      return;
+    }
     this._removeMarker();
     var defaultMarkerOptions = {
       color: '#4668F2'

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,7 @@ MapboxGeocoder.prototype = {
       if (parent.length == 0){
         throw new Error(`Element ${container} not found.`)
       }
+      
       parent.forEach((parentEl)=>{
         const el = this.onAdd(); //no map
         parentEl.appendChild(el);

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,11 +112,11 @@ MapboxGeocoder.prototype = {
       if (parent.length == 0){
         throw new Error("Element ", container, "not found.")
       }
-      
+
       parent.forEach(function(parentEl){
         const el = this.onAdd(); //no map
         parentEl.appendChild(el);
-      })
+      }.bind(this))
 
     }else{
       throw new Error("Error: addTo Container must be a mapbox-gl-js map or a html element reference")

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -357,6 +357,7 @@ test('Geocoder--no map', function(tt) {
     t.ok(Object.keys(geocoderRef).length, "A geocoder exists in the document");
     const containerChildRef = container.getElementsByClassName("mapboxgl-ctrl-geocoder");
     t.ok(Object.keys(containerChildRef).length, "A geocoder exists as a child to the specified element");
+    container.remove();
     t.end(); 
   });
 
@@ -401,6 +402,8 @@ test('Geocoder--no map', function(tt) {
           '90,45',
           'valid LngLat value populates in input'
         );
+        // teardown 
+        container.remove();
         t.end();
       })
     );
@@ -455,8 +458,24 @@ test('Geocoder#addTo', function(tt) {
     opts.enableEventLogging = false;
     container = document.createElement('div');
     container.className = "notAMap"
+    // we haven't added this container to the dom, we've only created it
     geocoder = new MapboxGeocoder(opts);
     t.throws(()=>{geocoder.addTo(container)}, 'addTo throws if the element is not found on the DOM');
+    t.end(); 
+  });
+
+  tt.test('throws if there are multiple matching elements', (t)=>{
+    const opts = {}
+    opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
+    const container1 = document.createElement('div');
+    container1.className = "notAMap"
+    const container2 = document.createElement('div');
+    container2.className = "notAMap"
+    document.body.appendChild(container1)
+    document.body.appendChild(container2)
+    geocoder = new MapboxGeocoder(opts);
+    t.throws(()=>{geocoder.addTo(".notAMap")}, 'addTo throws if there are too many matching elements');
     t.end(); 
   });
 


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

This PR allows using the mapbox-gl-geocoder plugin without a map, as requested in https://github.com/mapbox/mapbox-gl-geocoder/issues/270. 

Currently, the plugin is added to the map using the map's `addControl` method. In order to facilitate adding the map to other elements, I added a new `addTo` method on the geocoder class. If the addTo method is called with a mapbox-gl-js map, it will be added like normal (the map's addControl method will be called under the hood). If, on the other hand, `geocoder.addTo` is called with a string that looks like a reference to an HTML class or ID, it will add the search bar to that element. In these cases, the geocoder will have no `_map` property and all map-related methods (like updateProximity or flyTo result) will not be executed. 

This still needs tests and I want to make sure there's no edge cases where the lack of a map causes unexpected problems. 

I will also need to:
- return the debug page to it's original state
- Add a new mapbox-gl-js example that shows how to use the geocoder without the map 

\cc @kbauhausness @shabnomnom 


### Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
