### PR TITLE
Remove feature.id checks for event deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Master
+
+### Bug fixes 🐛
+
+- Fix event deduplication [#298](https://github.com/mapbox/mapbox-gl-geocoder/pull/298).
+
+
 ## v4.4.2
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,7 +272,7 @@ MapboxGeocoder.prototype = {
   },
   _onChange: function() {
     var selected = this._typeahead.selected;
-    if (selected  && selected.id !== this.lastSelected) {
+    if (selected  && selected.place_name !== this.lastSelected) {
       this._clearEl.style.display = 'none';
       if (this.options.flyTo) {
         var flyOptions;
@@ -311,7 +311,7 @@ MapboxGeocoder.prototype = {
 
       this._eventEmitter.emit('result', { result: selected });
       this.eventManager.select(selected, this);
-      this.lastSelected = selected.id;
+      this.lastSelected = selected.place_name;
     }
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -308,10 +308,9 @@ MapboxGeocoder.prototype = {
       this._inputEl.focus();
       this._inputEl.scrollLeft = 0;
       this._inputEl.setSelectionRange(0, 0);
-
+      this.lastSelected = JSON.stringify(selected);
       this._eventEmitter.emit('result', { result: selected });
       this.eventManager.select(selected, this);
-      this.lastSelected = JSON.stringify(selected);
     }
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,7 +272,7 @@ MapboxGeocoder.prototype = {
   },
   _onChange: function() {
     var selected = this._typeahead.selected;
-    if (selected  && selected.place_name !== this.lastSelected) {
+    if (selected  && JSON.stringify(selected) !== this.lastSelected) {
       this._clearEl.style.display = 'none';
       if (this.options.flyTo) {
         var flyOptions;
@@ -311,7 +311,7 @@ MapboxGeocoder.prototype = {
 
       this._eventEmitter.emit('result', { result: selected });
       this.eventManager.select(selected, this);
-      this.lastSelected = selected.place_name;
+      this.lastSelected = JSON.stringify(selected);
     }
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,6 +238,9 @@ MapboxGeocoder.prototype = {
       ? e.target.shadowRoot.activeElement
       : e.target;
     var value = target ? target.value : '';
+
+    this.lastSelected = null;
+
     if (!value) {
       this.fresh = true;
       // the user has removed all the text

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -1031,5 +1031,14 @@ test('geocoder', function(tt) {
     t.throws(function(){map.addControl(geocoder);}, "throws an error if no local geocoder is set")
     t.end();
   });
+  
+  tt.test('geocoder.lastSelected is reset on input', function(t){
+    setup();
+    geocoder.lastSelected = "abc123";
+    geocoder._onKeyDown(new KeyboardEvent('KeyDown'));
+    t.equals(geocoder.lastSelected, null)
+    t.end();
+  });
+
   tt.end();
 });

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -328,5 +328,57 @@ test('Geocoder#inputControl', function(tt) {
     t.ok(consoleSpy.calledOnce, 'the custom clear method was called');
     t.end();
   });
+
+
+  tt.test('event deduplication', function(t) {
+    setup({
+      types: 'place',
+      mapboxgl: mapboxgl
+    });
+    var clearEl = container.querySelector('.mapboxgl-ctrl-geocoder button');
+
+    t.plan(4);
+
+    var checkVal = null;
+
+    geocoder.on(
+      'result',
+      function() {
+        t.equals(typeof geocoder.lastSelected, 'string', 'last selected is a string');
+        t.notEqual(geocoder.lastSelected, checkVal, 'last selected has been updated');
+        checkVal = geocoder.lastSelected
+        clearEl.dispatchEvent(clickEvent);
+      }
+    );
+    geocoder.query('test');
+    geocoder.query('usa');
+  });
+
+  tt.test('event deduplication even when IDs are shared', function(t) {
+    setup({
+      types: 'place',
+      mapboxgl: mapboxgl
+    });
+    var clearEl = container.querySelector('.mapboxgl-ctrl-geocoder button');
+
+    t.plan(2);
+
+
+
+    var lastID = "test.abc123"
+
+    geocoder.on(
+      'result',
+      function() {
+        t.pass("The test was executed even with duplicate ids")
+        var selected = JSON.parse(geocoder.lastSelected);
+        selected.id = lastID
+        clearEl.dispatchEvent(clickEvent);
+      }
+    );
+    geocoder.query('test');
+    geocoder.query('usa');
+  });
+
   tt.end();
 });


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Deduplicating events by feature id was introduced in https://github.com/mapbox/mapbox-gl-geocoder/pull/229. While this prevents duplicate `result` events (https://github.com/tristen/suggestions/issues/13), it introduces (at least) two undesirable side effects. 

1. When using a localGeocoder, the result event will only be emitted once, manifesting in poor user experience by not zooming to the location of the second selection. (Bug reports: https://github.com/mapbox/mapbox-gl-geocoder/issues/281, https://github.com/mapbox/mapbox-gl-geocoder/issues/278). 
2. If features share the same ID (as reported in https://github.com/mapbox/mapbox-gl-geocoder/issues/293), subsequent selections will not emit the result event. 

This PR aims to fix the above two issues.

My initial thought is to use the `place_name` instead of the feature's ID as a field to deduplicate on. This should work for case (2) above, because the two addresses will have different place_names. However, for the local geocoder, if some features share the same place_name, the same behavior will continue to occur. While I expect that most users will have unique place names in their data, there is no requirement for uniqueness, so perhaps we should not rely on this alone.

Alternate approaches include:
(1) adding additional checks to see if the results came from the local Geocoder
(2) attempting (again) to solve the duplicate result emission in the suggestions library.  


 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
