### PR TITLE
HTML Debug Page

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -1,0 +1,60 @@
+<head>
+    <title>Mapbox-gl-geocoder</title>
+    <script src="./../bundle.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mapbox-gl/1.4.0/mapbox-gl.js"></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.css' rel='stylesheet' />
+    <link rel='stylesheet' href="./../lib/mapbox-gl-geocoder.css" />
+    <style>
+        #map {
+            height: 100%;
+            width: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id='map'></div>
+    <h1>Hi</h1>
+</body>
+
+<script>
+
+    mapboxgl.accessToken = window.localStorage.getItem('MapboxAccessToken');
+
+    var map = new mapboxgl.Map({
+        container: "map",
+        style: 'mapbox://styles/mapbox/streets-v9',
+        center: [-79.4512, 43.6568],
+        zoom: 13
+    });
+
+    var geocoder = new MapboxGeocoder({
+        accessToken: mapboxgl.accessToken,
+        trackProximity: true,
+        mapboxgl: mapboxgl
+    });
+
+    map.addControl(geocoder)
+
+
+    geocoder.on('results', function (e) {
+        console.log('results: ', e.features);
+    });
+
+    geocoder.on('result', function (e) {
+        console.log('result: ', e.result);
+    });
+
+    geocoder.on('clear', function (e) {
+        console.log('clear');
+    });
+
+    geocoder.on('loading', function (e) {
+        console.log('loading:', e.query);
+    });
+
+    geocoder.on('error', function (e) {
+        console.log('Error is', e.error);
+    });
+
+</script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "unpkg": "dist/mapbox-gl-geocoder.min.js",
   "style": "lib/mapbox-gl-geocoder.css",
   "scripts": {
-    "start": "budo debug/index.js --live -- -t brfs ",
+    "start": "budo lib/index.js:bundle.js --open debug  --live  -- -t brfs  --standalone MapboxGeocoder lib/index.js",
     "prepublish": "NODE_ENV=production && mkdir -p dist && browserify --standalone MapboxGeocoder lib/index.js | uglifyjs -c -m > dist/mapbox-gl-geocoder.min.js && cp lib/mapbox-gl-geocoder.css dist/",
     "test": "browserify -t envify test/index.js test/events.test.js | smokestack -b firefox | tap-status | tap-color",
     "docs": "documentation build lib/index.js --format=md > API.md",


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
As noted in #297, the existing javascript-only debug pages make it tricky to (1) understand typical usage of the geocoder plugin and (2) make changes to the debug pages, such as the one recently added in #295 (https://github.com/mapbox/mapbox-gl-geocoder/pull/295/commits/5830a8b2ad3fcb32bc35da99f4dc32beae25ec7b). 

This PR:
- removes the old javascript-only debug pages
- recreates their functionality in an easier-to-follow HTML + javascript + css set up
- changes the project `start` command to recognize the new html page.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
