### PR TITLE
Paste event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Master
+
+### Bug fixes 🐛
+- Add a paste event handler to ensure that paste events are recognized by the geocoder and trigger searches [#300](https://github.com/mapbox/mapbox-gl-geocoder/pull/300). 
+
 ## v4.4.2
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,6 @@ MapboxGeocoder.prototype = {
   _onPaste: function(e){
     var value = (e.clipboardData || window.clipboardData).getData('text');
     if (value.length >= this.options.minLength) {
-      console.log(value)
       this._geocode(value);
     }
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,7 @@ MapboxGeocoder.prototype = {
   },
 
   _onPaste: function(e){
-    var value = (e.clipboardData || e.clipboardData).getData('text');
+    var value = (e.clipboardData || window.clipboardData).getData('text');
     if (value.length >= this.options.minLength) {
       this._geocode(value);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,6 +229,7 @@ MapboxGeocoder.prototype = {
   _onPaste: function(e){
     var value = (e.clipboardData || window.clipboardData).getData('text');
     if (value.length >= this.options.minLength) {
+      console.log(value)
       this._geocode(value);
     }
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,7 @@ MapboxGeocoder.prototype = {
 
     this._onChange = this._onChange.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
+    this._onPaste = this._onPaste.bind(this);
     this._onBlur = this._onBlur.bind(this);
     this._showButton = this._showButton.bind(this);
     this._hideButton = this._hideButton.bind(this);
@@ -146,6 +147,7 @@ MapboxGeocoder.prototype = {
     }
 
     this._inputEl.addEventListener('keydown', debounce(this._onKeyDown, 200));
+    this._inputEl.addEventListener('paste', this._onPaste);
     this._inputEl.addEventListener('change', this._onChange);
     this.container.addEventListener('mouseenter', this._showButton);
     this.container.addEventListener('mouseleave', this._hideButton);
@@ -224,6 +226,13 @@ MapboxGeocoder.prototype = {
     return this;
   },
 
+  _onPaste: function(e){
+    var value = (e.clipboardData || e.clipboardData).getData('text');
+    if (value.length >= this.options.minLength) {
+      this._geocode(value);
+    }
+  },
+
   _onKeyDown: function(e) {
     var ESC_KEY_CODE = 27,
       TAB_KEY_CODE = 9;
@@ -238,6 +247,8 @@ MapboxGeocoder.prototype = {
       ? e.target.shadowRoot.activeElement
       : e.target;
     var value = target ? target.value : '';
+    
+
     if (!value) {
       this.fresh = true;
       // the user has removed all the text
@@ -246,7 +257,7 @@ MapboxGeocoder.prototype = {
     }
 
     // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
-    if (e.metaKey || [TAB_KEY_CODE, ESC_KEY_CODE, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1)
+    if ((e.metaKey || [TAB_KEY_CODE, ESC_KEY_CODE, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1))
       return;
 
     if (target.value.length >= this.options.minLength) {

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -1031,5 +1031,49 @@ test('geocoder', function(tt) {
     t.throws(function(){map.addControl(geocoder);}, "throws an error if no local geocoder is set")
     t.end();
   });
+
+  tt.test('geocoder#onPaste', function(t){
+    setup();
+    var searchMock = sinon.spy(geocoder, "_geocode")
+    var event = new ClipboardEvent('paste', {
+      dataType: 'text/plain', 
+      data: 'Golden Gate Bridge'
+    })
+    geocoder._onPaste(event);
+    t.ok(searchMock.calledOnce, 'the search was triggered');
+    const queryArg = searchMock.args[0][0];
+    t.equals(queryArg, 'Golden Gate Bridge', 'the paste event triggered the correct geocode');
+    searchMock.restore();
+    t.end();
+  });
+
+  tt.test('geocoder#onPaste not triggered when text is too short', function(t){
+    setup({
+      minLength: 5
+    });
+    var searchMock = sinon.spy(geocoder, "_geocode")
+    var event = new ClipboardEvent('paste', {
+      dataType: 'text/plain', 
+      data: 'abc'
+    })
+    geocoder._onPaste(event);
+    t.notOk(searchMock.calledOnce, 'the search was not triggered');
+    searchMock.restore();
+    t.end();
+  });
+
+  tt.test('geocoder#onPaste not triggered when there is no text', function(t){
+    setup();
+    var searchMock = sinon.spy(geocoder, "_geocode")
+    var event = new ClipboardEvent('paste', {
+      dataType: 'text/plain', 
+      data: ''
+    })
+    geocoder._onPaste(event);
+    t.notOk(searchMock.calledOnce, 'the search was not triggered');
+    searchMock.restore();
+    t.end();
+  });
+
   tt.end();
 });

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -328,5 +328,25 @@ test('Geocoder#inputControl', function(tt) {
     t.ok(consoleSpy.calledOnce, 'the custom clear method was called');
     t.end();
   });
+
+  tt.test('paste event', function(t) {
+    t.plan(1);
+    setup({ });
+    var pasteEvent = new ClipboardEvent('paste', {
+      dataType: 'text/plain', 
+      data: 'Golden Gate Bridge'
+    })
+    var inputEl = container.querySelector('.mapboxgl-ctrl-geocoder input');
+    inputEl.dispatchEvent(pasteEvent)
+
+    geocoder.on(
+      'results',
+      once(function() {
+        t.pass("results are returned");
+        t.end();
+      })
+    );
+  });
+
   tt.end();
 });


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fixes the paste issue reported in #140 by adding an `onPaste` event to the geocoder. 

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
