### PR TITLE
only add a marker if center present in result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fix event deduplication [#298](https://github.com/mapbox/mapbox-gl-geocoder/pull/298).
 - Add a paste event handler to ensure that paste events are recognized by the geocoder and trigger searches [#300](https://github.com/mapbox/mapbox-gl-geocoder/pull/300). 
+- Fix a bug where geocoding responses without a center would try to add a Marker [#301](https://github.com/mapbox/mapbox-gl-geocoder/pull/301)
 
 ## v4.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+### Bug fixes 🐛
+
+- Fix a bug where geocoding responses without a center would try to add a Marker [#301](https://github.com/mapbox/mapbox-gl-geocoder/pull/301)
+
 ## v4.5.0
 ### Features / Improvements 🚀
 
@@ -8,7 +13,6 @@
 
 - Fix event deduplication [#298](https://github.com/mapbox/mapbox-gl-geocoder/pull/298).
 - Add a paste event handler to ensure that paste events are recognized by the geocoder and trigger searches [#300](https://github.com/mapbox/mapbox-gl-geocoder/pull/300). 
-- Fix a bug where geocoding responses without a center would try to add a Marker [#301](https://github.com/mapbox/mapbox-gl-geocoder/pull/301)
 
 ## v4.4.2
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -922,10 +922,12 @@ MapboxGeocoder.prototype = {
       color: '#4668F2'
     }
     var markerOptions = extend({}, defaultMarkerOptions, this.options.marker)
-    this.mapMarker = new this._mapboxgl.Marker(markerOptions);
-    this.mapMarker
-      .setLngLat(selected.center)
-      .addTo(this._map);
+    if (selected.center) {
+      this.mapMarker = new this._mapboxgl.Marker(markerOptions);
+      this.mapMarker
+        .setLngLat(selected.center)
+        .addTo(this._map);
+    }
     return this;
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -922,10 +922,14 @@ MapboxGeocoder.prototype = {
       color: '#4668F2'
     }
     var markerOptions = extend({}, defaultMarkerOptions, this.options.marker)
+    this.mapMarker = new this._mapboxgl.Marker(markerOptions);
     if (selected.center) {
-      this.mapMarker = new this._mapboxgl.Marker(markerOptions);
       this.mapMarker
         .setLngLat(selected.center)
+        .addTo(this._map);
+    } else if (selected.geometry && selected.geometry.type && selected.geometry.type === 'Point' && selected.geometry.coordinates) {
+      this.mapMarker
+        .setLngLat(selected.geometry.coordinates)
         .addTo(this._map);
     }
     return this;


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

If the geocoding response only contains a `bbox` and no `center` then don't try to add a marker to the map (which would fail anyway).

 - [ ] write tests for all new functionality

I'd love to add a test, but because the tests currently query the live API, it would require a bit of work to put in place a mock instead.

 - [ ] ~~run `npm run docs` and commit changes to API.md~~
 - [x] update CHANGELOG.md with changes under `master` heading before merging
