### PR TITLE
allow results with no properties but with bbox

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -326,13 +326,7 @@ MapboxGeocoder.prototype = {
       this._clearEl.style.display = 'none';
       if (this.options.flyTo) {
         var flyOptions;
-        if (selected.properties && !exceptions[selected.properties.short_code] && selected.bbox) {
-          var bbox = selected.bbox;
-          flyOptions = extend({}, this.options.flyTo);
-          if (this._map){
-            this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
-          }
-        } else if (selected.properties && exceptions[selected.properties.short_code]) {
+        if (selected.properties && exceptions[selected.properties.short_code]) {
           // Certain geocoder search results return (and therefore zoom to fit)
           // an unexpectedly large bounding box: for example, both Russia and the
           // USA span both sides of -180/180, or France includes the island of
@@ -342,6 +336,12 @@ MapboxGeocoder.prototype = {
           flyOptions = extend({}, this.options.flyTo);
           if (this._map){
             this._map.fitBounds(exceptions[selected.properties.short_code].bbox, flyOptions);
+          }
+        } else if (selected.bbox) {
+          var bbox = selected.bbox;
+          flyOptions = extend({}, this.options.flyTo);
+          if (this._map){
+            this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
           }
         } else {
           var defaultFlyOptions = {


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

If a geocoding response lacks `properties` but has `bbox`, in master, it won't use the bbox. This PR fixes that to use a bbox over center when no properties exists.

 - [ ] write tests for all new functionality
 - [ ] ~~run `npm run docs` and commit changes to API.md~~
 - [x] update CHANGELOG.md with changes under `master` heading before merging
