### PR TITLE
Add example using the addTo method

### DIFF
--- a/API.md
+++ b/API.md
@@ -125,7 +125,7 @@ For example, if the HTML body contains the element `<div id='geocoder-container'
 
 ```javascript
 var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
-map.addTo('#geocoder-container');
+geocoder.addTo('#geocoder-container');
 ```
 
 #### Parameters

--- a/API.md
+++ b/API.md
@@ -113,13 +113,20 @@ Returns **[MapboxGeocoder][68]** `this`
 
 ### addTo
 
-Add the geocoder to a container. The container can be either a mapboxgl.Map or a reference to an HTML class or ID. 
+Add the geocoder to a container. The container can be either a `mapboxgl.Map` or a reference to an HTML `class` or `id`.
 
-If the container is a mapboxgl.Map, this function will behave identically to Map.addControl(geocoder)
-If the container is an html id or class, the geocoder will be appended to that element
+If the container is a `mapboxgl.Map`, this function will behave identically to ```Map.addControl(geocoder)``.
+If the container is an HTML```id`or`class\`, the geocoder will be appended to that element.
 
-This function will throw an error if the container is not one a map or a class/id reference
-It will also throw an error if the referenced html element cannot be found in the document.body
+This function will throw an error if the container is not either a map or a `class`/`id` reference.
+It will also throw an error if the referenced HTML element cannot be found in the `document.body`.
+
+For example, if the HTML body contains the element `<div id='geocoder-container'></div>`, the following script will append the geocoder to `#geocoder-container`:
+
+```javascript
+var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
+map.addTo('#geocoder-container');
+```
 
 #### Parameters
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,8 @@ var subtag = require('subtag');
  * @param {Boolean|Object} [options.marker=true]  If `true`, a [Marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker) will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set.
  * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. Accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. Any html in the returned string will be rendered.
  * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object  as input and return a string. HTML tags in the output string will not be rendered.
- * @param {String} [options.mode='mapbox.places'] A string specifying the geocoding [endpoint](https://docs.mapbox.com/api/search/#endpoints) to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. 
- * @param {Boolean} [options.localGeocoderOnly] If `true`, indicates that the localGeocoder results should be the only ones returned to the user. If `false`, indicates that the localGeocoder results should be combined with those from the Mapbox API. 
+ * @param {String} [options.mode='mapbox.places'] A string specifying the geocoding [endpoint](https://docs.mapbox.com/api/search/#endpoints) to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes.
+ * @param {Boolean} [options.localGeocoderOnly] If `true`, indicates that the localGeocoder results should be the only ones returned to the user. If `false`, indicates that the localGeocoder results should be combined with those from the Mapbox API.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -91,19 +91,26 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Add the geocoder to a container. The container can be either a mapboxgl.Map or a reference to an HTML class or ID. 
-   * 
-   * If the container is a mapboxgl.Map, this function will behave identically to Map.addControl(geocoder)
-   * If the container is an html id or class, the geocoder will be appended to that element
-   * 
-   * This function will throw an error if the container is not one a map or a class/id reference
-   * It will also throw an error if the referenced html element cannot be found in the document.body
-   * @param {String|mapboxgl.Map} container A reference to the container to which to add the geocoder 
+   * Add the geocoder to a container. The container can be either a `mapboxgl.Map` or a reference to an HTML `class` or `id`.
+   *
+   * If the container is a `mapboxgl.Map`, this function will behave identically to `Map.addControl(geocoder)``.
+   * If the container is an HTML `id` or `class`, the geocoder will be appended to that element.
+   *
+   * This function will throw an error if the container is not either a map or a `class`/`id` reference.
+   * It will also throw an error if the referenced HTML element cannot be found in the `document.body`.
+   *
+   * For example, if the HTML body contains the element `<div id='geocoder-container'></div>`, the following script will append the geocoder to `#geocoder-container`:
+   *
+   * ```javascript
+   * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
+   * map.addTo('#geocoder-container');
+   * ```
+   * @param {String|mapboxgl.Map} container A reference to the container to which to add the geocoder
    */
   addTo: function(container){
     // if the container is a map, add the control like normal
     if (container._controlContainer){
-      //  it's a mapbox-gl map, add like normal 
+      //  it's a mapbox-gl map, add like normal
       container.addControl(this)
     }
     // if the container is not a map, but an html element, then add the control to that element
@@ -140,7 +147,7 @@ MapboxGeocoder.prototype = {
           accessToken: this.options.accessToken,
           origin: this.options.origin
         })
-      );  
+      );
     }
 
     if (this.options.localGeocoderOnly && !this.options.localGeocoder){
@@ -887,7 +894,7 @@ MapboxGeocoder.prototype = {
         accessToken: this.options.accessToken,
         origin: this.options.origin
       })
-    );  
+    );
     return this;
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ MapboxGeocoder.prototype = {
    *
    * ```javascript
    * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
-   * map.addTo('#geocoder-container');
+   * geocoder.addTo('#geocoder-container');
    * ```
    * @param {String|mapboxgl.Map} container A reference to the container to which to add the geocoder
    */


### PR DESCRIPTION
This PR adds an example to API.md (by updating the function docstring in `lib/index.js` and running `npm run docs`) for using the geocoder plugin without a map. The example clarifies that the `class`/`id` name must be appropriately prepended with `.` or `#` to be passed to the `geocoder.addTo` method.