### PR TITLE
allow HTMLElement to be used as geocoder parent

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,10 +115,11 @@ Returns **[MapboxGeocoder][68]** `this`
 
 Add the geocoder to a container. The container can be either a `mapboxgl.Map` or a reference to an HTML `class` or `id`.
 
-If the container is a `mapboxgl.Map`, this function will behave identically to ```Map.addControl(geocoder)``.
-If the container is an HTML```id`or`class\`, the geocoder will be appended to that element.
+If the container is a `mapboxgl.Map`, this function will behave identically to \`Map.addControl(geocoder)``.
+If the container is an instance of HTMLElement, then the geocoder will be 
+If the container is a CSS selector string, the geocoder will be appended to the element returned from the query.
 
-This function will throw an error if the container is not either a map or a `class`/`id` reference.
+This function will throw an error if the container is none of the above.
 It will also throw an error if the referenced HTML element cannot be found in the `document.body`.
 
 For example, if the HTML body contains the element `<div id='geocoder-container'></div>`, the following script will append the geocoder to `#geocoder-container`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 ### Features / Improvements 🚀
 
-- Support passing an HTMLElement as the parent for a Geocoder - builds on top of [#270] - 
+- Support passing an HTMLElement as the parent for a Geocoder - builds on top of [#270] - [#311](https://github.com/mapbox/mapbox-gl-geocoder/pull/311)
 
 ### Bug fixes 🐛
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## master
+### Features / Improvements 🚀
+
+- Support passing an HTMLElement as the parent for a Geocoder - builds on top of [#270] - 
+
 ### Bug fixes 🐛
 
 - Fix a bug where geocoding responses without a center would try to add a Marker [#301](https://github.com/mapbox/mapbox-gl-geocoder/pull/301)

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,9 +94,10 @@ MapboxGeocoder.prototype = {
    * Add the geocoder to a container. The container can be either a `mapboxgl.Map` or a reference to an HTML `class` or `id`.
    *
    * If the container is a `mapboxgl.Map`, this function will behave identically to `Map.addControl(geocoder)``.
-   * If the container is an HTML `id` or `class`, the geocoder will be appended to that element.
+   * If the container is an instance of HTMLElement, then the geocoder will be 
+   * If the container is a CSS selector string, the geocoder will be appended to the element returned from the query.
    *
-   * This function will throw an error if the container is not either a map or a `class`/`id` reference.
+   * This function will throw an error if the container is none of the above.
    * It will also throw an error if the referenced HTML element cannot be found in the `document.body`.
    *
    * For example, if the HTML body contains the element `<div id='geocoder-container'></div>`, the following script will append the geocoder to `#geocoder-container`:
@@ -108,15 +109,25 @@ MapboxGeocoder.prototype = {
    * @param {String|mapboxgl.Map} container A reference to the container to which to add the geocoder
    */
   addTo: function(container){
+
+    function addToExistingContainer (container) {
+      const el = this.onAdd(); //returns the input elements, which are then added to the requested html container
+      container.appendChild(el);
+    }
+
     // if the container is a map, add the control like normal
     if (container._controlContainer){
       //  it's a mapbox-gl map, add like normal
-      container.addControl(this)
+      container.addControl(this);
     }
-    // if the container is not a map, but an html element, then add the control to that element
-    else if (typeof container == 'string' && (container.startsWith('#') || container.startsWith('.'))){
+    // if the container is an HTMLElement, then set the parent to be that element
+    else if (container instanceof HTMLElement) {
+      addToExistingContainer(container).bind(this);
+    }
+    // if the container is a string, treat it as a CSS query
+    else if (typeof container == 'string'){
       const parent = document.querySelectorAll(container);
-      if (parent.length == 0){
+      if (parent.length === 0){
         throw new Error("Element ", container, "not found.")
       }
 
@@ -124,13 +135,9 @@ MapboxGeocoder.prototype = {
         throw new Error("Geocoder can only be added to a single html element")
       }
 
-      parent.forEach(function(parentEl){
-        const el = this.onAdd(); //returns the input elements, which are then added to the requested html container
-        parentEl.appendChild(el);
-      }.bind(this))
-
+      addToExistingContainer(parent[0]);
     }else{
-      throw new Error("Error: addTo Container must be a mapbox-gl-js map or a html element reference")
+      throw new Error("Error: addTo must be a mapbox-gl-js map, an html element, or a CSS selector query for a single html element")
     }
   },
 

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -504,7 +504,20 @@ test('Geocoder#addTo', function(tt) {
     container.className = "notAMap"
     document.body.appendChild(container)
     geocoder = new MapboxGeocoder(opts);
-    geocoder.addTo(".notAMap")
+    geocoder.addTo(".notAMap");
+    t.ok(Object.keys(container.getElementsByClassName("mapboxgl-ctrl-geocoder--input")).length, 'geocoder exists when added to an html element')
+    t.end(); 
+  });
+
+  tt.test('add to an existing HTMLElement', (t)=>{
+    const opts = {}
+    opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
+    container = document.createElement('div');
+    container.className = "notAMapEither"
+    document.body.appendChild(container)
+    geocoder = new MapboxGeocoder(opts);
+    geocoder.addTo(document.querySelectorAll(".notAMapEither"));
     t.ok(Object.keys(container.getElementsByClassName("mapboxgl-ctrl-geocoder--input")).length, 'geocoder exists when added to an html element')
     t.end(); 
   });


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR
 - [X] write tests for all new functionality
 - [X] run `npm run docs` and commit changes to API.md
 - [X] update CHANGELOG.md with changes under `master` heading before merging

This was mentioned by a reviewer on the original PR, but was never incorporated. Using HTMLElements themselves is the recommended way of passing references to DOM elements in frameworks like [Svelte](https://svelte.dev) as generally `document.querySelector` and it's ilk are discouraged there.