### PR TITLE
remove last selected from keydown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug fixes 🐛
 
 - Fix a bug where geocoding responses without a center would try to add a Marker [#301](https://github.com/mapbox/mapbox-gl-geocoder/pull/301)
+- Fix a bug where result was not selected on subsequent `localGeocoder` searches [#315](https://github.com/mapbox/mapbox-gl-geocoder/pull/315)
 
 ## v4.5.0
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,8 +294,6 @@ MapboxGeocoder.prototype = {
       : e.target;
     var value = target ? target.value : '';
 
-    this.lastSelected = null;
-
     if (!value) {
       this.fresh = true;
       // the user has removed all the text


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fixes https://github.com/mapbox/mapbox-gl-geocoder/issues/309 by removing the `lastSelected` value from the keydown method. 


 - [x] briefly describe the changes in this PR
 - [x] update CHANGELOG.md with changes under `master` heading before merging
