### PR TITLE
use placeholder value for input element aria-label

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -769,6 +769,7 @@ MapboxGeocoder.prototype = {
   setPlaceholder: function(placeholder){
     this.placeholder = (placeholder) ? placeholder : this._getPlaceholderText();
     this._inputEl.placeholder = this.placeholder;
+    this._inputEl.setAttribute('aria-label', this.placeholder);
     return this
   },
 


### PR DESCRIPTION
Hello, this adds a small accessibility improvement: adding an aria-label to the input element.

I debated whether a new option would be best and ultimately reused the placeholder value as the aria-label value.

In most cases, and certainly in the default case of `Search`, it makes sense for the placeholder and the aria-label to be the same.

Happy to make any needed changes to get this merged.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
