### PR TITLE
disable proximity when reverseGeocoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+### Bug fixes 🐛
+- disable proximity when reverseGeocoding since it is not supported by the Mapbox Geocoding API [#327](https://github.com/mapbox/mapbox-gl-geocoder/pull/327)
+
 ## v4.5.1
 ### Bug fixes 🐛
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -436,6 +436,12 @@ MapboxGeocoder.prototype = {
       // use first config type if one, if not default to poi
       config.types ? [config.types[0]] : ["poi"];
       config = extend(config, { query: coords, limit: 1 });
+
+      // drop proximity which may have been set by trackProximity since it's not supported by the reverseGeocoder
+      if ('proximity' in config) {
+        delete config.proximity;
+      }
+
       request = this.geocoderService.reverseGeocode(config).send();
     } else {
       config = extend(config, { query: searchInput });

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -196,6 +196,20 @@ test('geocoder', function(tt) {
     );
   });
 
+  tt.test('options.reverseGeocode: true with trackProximity: true', function(t) {
+    t.plan(0);
+    setup({
+      reverseGeocode: true,
+      trackProximity: true
+    });
+    map.jumpTo({
+      zoom: 16,
+      center: [10, 10]
+    });
+    geocoder.query('-6.1933875, 34.5177548');
+    t.end();
+  });
+
   tt.test('parses options correctly', function(t) {
     t.plan(4);
     setup({


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
closes #318. Since proximity is not supported by the reverseGeocoder, this disables it if it was set by trackProximity.
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
