### PR TITLE
Fix formatting in list of available events for on listener

### DIFF
--- a/API.md
+++ b/API.md
@@ -374,7 +374,8 @@ Subscribe to events that happen within the plugin.
 
 #### Parameters
 
--   `type` **[String][57]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
+-   `type` **[String][57]** name of event. Available events and the data passed into their respective event objects are:
+    -   **clear** `Emitted when the input is cleared`
     -   **loading** `{ query } Emitted when the geocoder is looking up a query`
     -   **results** `{ results } Fired when the geocoder returns a response`
     -   **result** `{ result } Fired when input is set`


### PR DESCRIPTION
 - [x] briefly describe the changes in this PR

Previously, the `clear` event was not on its own line. Now it is.