### PR TITLE
#344: Fix for results not firing on setInput

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -661,7 +661,9 @@ MapboxGeocoder.prototype = {
     this._inputEl.value = searchInput;
     this._typeahead.selected = null;
     this._typeahead.clear();
-    this._geocode(searchInput);
+    if (searchInput.length >= this.options.minLength) {
+      this._geocode(searchInput);
+    }
     return this;
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -661,7 +661,7 @@ MapboxGeocoder.prototype = {
     this._inputEl.value = searchInput;
     this._typeahead.selected = null;
     this._typeahead.clear();
-    this._onChange();
+    this._geocode(searchInput);
     return this;
   },
 


### PR DESCRIPTION
This change causes calls to `setInput` to behave in the same manner as a `keyDown` event, that is returning suggestions based on the input.
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] update CHANGELOG.md with changes under `master` heading before merging

closes #344 