### PR TITLE
remove MapboxAccessToken from travis global env since it's already set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - '6'
-env:
-  global: MapboxAccessToken
 addons:
   apt:
     update: true


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
as noted at https://github.com/mapbox/mapbox-gl-geocoder/pull/353#issuecomment-620328424, on Travis, the Mapbox token is already set globally and so we need to remove this to avoid it being re-set to '' and hence breaking builds.
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
