### PR TITLE
fix failing test which was missing bind, add tests for element scenario

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,9 @@ MapboxGeocoder.prototype = {
   addTo: function(container){
 
     function addToExistingContainer (geocoder, container) {
+      if (!document.body.contains(container)) {
+        throw new Error("Element provided to #addTo() exists, but is not in the DOM")
+      }
       const el = geocoder.onAdd(); //returns the input elements, which are then added to the requested html container
       container.appendChild(el);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,8 +110,8 @@ MapboxGeocoder.prototype = {
    */
   addTo: function(container){
 
-    function addToExistingContainer (container) {
-      const el = this.onAdd(); //returns the input elements, which are then added to the requested html container
+    function addToExistingContainer (geocoder, container) {
+      const el = geocoder.onAdd(); //returns the input elements, which are then added to the requested html container
       container.appendChild(el);
     }
 
@@ -122,7 +122,7 @@ MapboxGeocoder.prototype = {
     }
     // if the container is an HTMLElement, then set the parent to be that element
     else if (container instanceof HTMLElement) {
-      addToExistingContainer(container).bind(this);
+      addToExistingContainer(this, container);
     }
     // if the container is a string, treat it as a CSS query
     else if (typeof container == 'string'){
@@ -135,7 +135,7 @@ MapboxGeocoder.prototype = {
         throw new Error("Geocoder can only be added to a single html element")
       }
 
-      addToExistingContainer(parent[0]);
+      addToExistingContainer(this, parent[0]);
     }else{
       throw new Error("Error: addTo must be a mapbox-gl-js map, an html element, or a CSS selector query for a single html element")
     }

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -401,7 +401,7 @@ test('Geocoder#inputControl', function(tt) {
   tt.end();
 });
 
-test('Geocoder--no map', function(tt) {
+test('Geocoder#addTo(String) -- no map', function(tt) {
   var container, geocoder;
 
   var changeEvent = document.createEvent('HTMLEvents');
@@ -430,7 +430,6 @@ test('Geocoder--no map', function(tt) {
     container.remove();
     t.end(); 
   });
-
 
   tt.test('input works without a map', function(t) {
     setup({
@@ -482,7 +481,39 @@ test('Geocoder--no map', function(tt) {
   });
 });
 
-test('Geocoder#addTo', function(tt) {
+
+test('Geocoder#addTo(HTMLElement) -- no map', function(tt) {
+  var container, geocoder;
+
+  var changeEvent = document.createEvent('HTMLEvents');
+  changeEvent.initEvent('change', true, false);
+
+  var clickEvent = document.createEvent('HTMLEvents');
+  clickEvent.initEvent('click', true, false);
+
+  function setup(opts) {
+    opts = opts || {};
+    opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
+    container = document.createElement('div');
+    container.className = "notAMap"
+    document.body.appendChild(container)
+    geocoder = new MapboxGeocoder(opts);
+    geocoder.addTo(".notAMap")
+  }
+
+  tt.test('result was added to container', (t)=>{
+    setup();
+    const geocoderRef = document.getElementsByClassName("mapboxgl-ctrl-geocoder");
+    t.ok(Object.keys(geocoderRef).length, "A geocoder exists in the document");
+    const containerChildRef = container.getElementsByClassName("mapboxgl-ctrl-geocoder");
+    t.ok(Object.keys(containerChildRef).length, "A geocoder exists as a child to the specified element");
+    container.remove();
+    t.end(); 
+  });
+});
+
+test('Geocoder#addTo(mapboxgl.Map)', function(tt) {
   var container, geocoder;
 
   tt.test('add to an existing map', (t)=>{

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -546,23 +546,10 @@ test('Geocoder#addTo(mapboxgl.Map)', function(tt) {
     opts.accessToken = mapboxgl.accessToken;
     opts.enableEventLogging = false;
     container = document.createElement('div');
-    container.className = "notAMapEither"
     document.body.appendChild(container)
     geocoder = new MapboxGeocoder(opts);
-    geocoder.addTo(document.querySelectorAll(".notAMapEither"));
+    geocoder.addTo(container);
     t.ok(Object.keys(container.getElementsByClassName("mapboxgl-ctrl-geocoder--input")).length, 'geocoder exists when added to an html element')
-    t.end(); 
-  });
-
-  tt.test('throws if added to an unknown element', (t)=>{
-    const opts = {}
-    opts.accessToken = mapboxgl.accessToken;
-    opts.enableEventLogging = false;
-    container = document.createElement('div');
-    container.className = "notAMap"
-    document.body.appendChild(container)
-    geocoder = new MapboxGeocoder(opts);
-    t.throws(()=>{geocoder.addTo(container)}, 'addTo throws if added to an unknown element');
     t.end(); 
   });
 


### PR DESCRIPTION
This fixes https://github.com/mapbox/mapbox-gl-geocoder/issues/379 which was caused by my previous PR not binding the inner method correctly.

I'm still having failures with `.flyTo` locally but I get these on master anyway so I'm quite sure they're not related to my fix.

I am getting one failure about adding to a container (but it doesn't relate to my change), so just trying to determine if this is something to do with the PR or not.

Opening this for review whilst I do that work.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
