### PR TITLE
where the supplied externalGeocoder method returns null, such as when after inspecting the search input it decides an external request is not needed, gracefully handle it by resolving with an empty results response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -502,8 +502,7 @@ MapboxGeocoder.prototype = {
             : localGeocoderRes;
 
           if (this.options.externalGeocoder) {
-
-            externalGeocoderRes = this.options.externalGeocoder(searchInput, res.features) || [];
+            externalGeocoderRes = this.options.externalGeocoder(searchInput, res.features) || Promise.resolve([]);
             // supplement Mapbox Geocoding API results with features returned by a promise
             return externalGeocoderRes.then(function(features) {
               res.features = res.features ? features.concat(res.features) : features;


### PR DESCRIPTION
 - [x] briefly describe the changes in this PR

This issue was found by @ogdenstudios in https://github.com/mapbox/mapbox-gl-geocoder/issues/34#issuecomment-683362574

It is triggered by the demo, where after inspecting the search input it decides not to return a promise and instead returns null, in these cases it looks like the original code intended to handle this situation gracefully by returning an empty results, and I agree that should happen, however, because in the subsequent line at https://github.com/mapbox/mapbox-gl-geocoder/blob/a5591a3cab9e3d133aeff99d4f31a659f9d9d614/lib/index.js#L508 it tries to call .then, it must be a Promise not `[]`.

 - [ ] write tests for all new functionality
This should be done, but I haven't yet so leaving this PR in draft.

 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging

@mapbox-danny would you mind taking a look please?