### PR TITLE
in the demo, where no results are found, then still check the mock external geocoder

### DIFF
--- a/debug/index.js
+++ b/debug/index.js
@@ -79,7 +79,7 @@ var geocoder = new MapboxGeocoder({
   },
   externalGeocoder: function(query, features) {
     // peak at the query and features before calling the external api
-    if(query.length > 5 && features[0].relevance != 1) {
+    if(query.length > 5 && (features.length ? features[0].relevance != 1 : true)) {
       return fetch('/mock-api.json')
         .then(response => response.json())
     }


### PR DESCRIPTION
 - [x] briefly describe the changes in this PR

in the demo if there are no results found, there is an error accessing the first result, I think this is what was intended, @mapbox-danny are you able to take a look?

 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
