### PR TITLE
upgrade travis config to node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '6'
+  - '12'
 addons:
   apt:
     update: true


### PR DESCRIPTION
 - [x] briefly describe the changes in this PR

looks like from https://travis-ci.com/github/mapbox/mapbox-gl-geocoder/builds/181944071 that nvm can't install node 6, node 6 is EOL, so upgrading to the current LTS.
