### PR TITLE
Fix setMinLength not applying to typeahead

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -893,7 +893,7 @@ MapboxGeocoder.prototype = {
    */
   setMinLength: function(minLength){
     this.options.minLength = minLength;
-    if (this._typeahead)  this._typeahead.minLength = minLength;
+    if (this._typeahead)  this._typeahead.options.minLength = minLength;
     return this;
   },
 


### PR DESCRIPTION
The implementation of setMinLength doesn't work properly - it doesn't actually apply the minLength property to the typeahead. An example of the correct functionality is seen in setLimit.

This PR fixes setMinLength by changing `this._typeahead.options.minLength` instead of `this._typeahead.minLength`.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality (no new functionality)
 - [x] run `npm run docs` and commit changes to API.md (no changes)
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
