### PR TITLE
Fix window is not defined issue when doing server side rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11332,9 +11332,9 @@
       "integrity": "sha512-CaIBcTSb/nyk4xiiSOtZYz1B+F12ZxW8NEp54CdT+84vmh/h4sUnHGC6+KQXUfED8u22PQjCYWfZny8d2ELXwg=="
     },
     "suggestions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/suggestions/-/suggestions-1.6.0.tgz",
-      "integrity": "sha512-U0UD0k9qxUm1VcHhoQm7UmBGUNjrHQSIZGnKLvk/a91uAp6zPVujxxuQm0SSq7sExDIAUtoQJvapLeeM6ZGVCg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/suggestions/-/suggestions-1.7.1.tgz",
+      "integrity": "sha512-gl5YPAhPYl07JZ5obiD9nTZsg4SyZswAQU/NNtnYiSnFkI3+ZHuXAiEsYm7AaZ71E0LXSFaGVaulGSWN3Gd71A==",
       "requires": {
         "fuzzy": "^0.1.1",
         "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash.debounce": "^4.0.6",
     "nanoid": "^2.0.1",
     "subtag": "^0.5.0",
-    "suggestions": "^1.6.0",
+    "suggestions": "^1.7.1",
     "xtend": "^4.0.1"
   },
   "lint-staged": {


### PR DESCRIPTION
This fixes the `window is not defined` error when doing server side rendering. The `suggestions` dependency is what was causing this issue and this issue has been fixed in v1.7.1. PR that fixed the issue https://github.com/tristen/suggestions/pull/42.
