### PR TITLE
upgrade mapbox-gl peerDependency to work with GL JS 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uglify-js": "^2.6.4"
   },
   "peerDependencies": {
-    "mapbox-gl": ">= 0.47.0 < 2.0.0"
+    "mapbox-gl": ">= 0.47.0 < 3.0.0"
   },
   "dependencies": {
     "@mapbox/mapbox-sdk": "^0.11.0",


### PR DESCRIPTION
closes #412 

 - [x] briefly describe the changes in this PR
 - N/A write tests for all new functionality
tested all the examples with gl js 2 and they seem fine
 - N/A run `npm run docs` and commit changes to API.md
 - N/A update CHANGELOG.md with changes under `master` heading before merging

@bastianonm

