### PR TITLE
Fix flyTo coordinates not set when selected.center is not defined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -375,7 +375,12 @@ MapboxGeocoder.prototype = {
           }
           flyOptions = extend({}, defaultFlyOptions, this.options.flyTo);
           //  ensure that center is not overriden by custom options
-          flyOptions.center = selected.center;
+          if (selected.center) {
+            flyOptions.center = selected.center;
+          } else if (selected.geometry && selected.geometry.type && selected.geometry.type === 'Point' && selected.geometry.coordinates) {
+            flyOptions.center = selected.geometry.coordinates;
+          }
+          
           if (this._map){
             this._map.flyTo(flyOptions);
           }


### PR DESCRIPTION
Currently when `selected.center` is not defined the `flyTo` action will just zoom in on the currently viewed area. Fixed this to be similar to how `selected.center` and `selected.geometry.coordinates` are handled in `_handleMarker` so that either can be used as the flyTo destination.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality (no new functionality)
 - [x] run `npm run docs` and commit changes to API.md (no changes)
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
