### PR TITLE
Prepare to release v4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## master
 
+## 4.7.1
+
+### Features / Improvements 🚀
+
+- Added russian placeholder [#409](https://github.com/mapbox/mapbox-gl-geocoder/pull/409)
+
+### Bug fixes 🐛
+
+- Fixed an error in the demo when no results are found [#391](https://github.com/mapbox/mapbox-gl-geocoder/pull/391)
+- Fixed `setMinLength` to correctly apply the `minLength` property to the typeahead [#399](https://github.com/mapbox/mapbox-gl-geocoder/pull/399)
+- Updated the `mapbox-gl` peerDependency to work with GL JS 2 [#413](https://github.com/mapbox/mapbox-gl-geocoder/pull/413)
+
 ## 4.7.0
 
 ### Features / Improvements 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",


### PR DESCRIPTION
As suggested in #414, this PR prepares for a release of v4.7.1 of this package. A maintainer will have to do the final few steps of actually tagging and publishing it, so basically this PR just updates the changelog and package.json for you.

I will gladly update any docs too, but the repo listed in the checklist below doesn't exist, so I'm not sure where to do that.

@andrewharvey hope you don't mind me tagging you to take a look at this, I can't request a review from you directly.

Closes #414.

---

Copied from CONTRIBUTING.md:

## Release checklist

1. Create a branch off `master` and a pull request with the following changes. Copy this checklist in the comment of the pull request.
    - [x] Update the [CHANGELOG.md](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/CHANGELOG.md) by comparing the last release and what is on `master`. In the changelog, replace the `master` heading with the to-be-released stable version.
    - [x] Update the version number in `package.json` and `package-lock.json`.
3. Request a PR review and then merge it into `master`.
4. Tag the release and start the build.
    - [x] Make sure you've pulled in all changes to `master` locally.
    - [x] Build the release with `npm run prepublish && npm run docs`
    - [ ] Commit and push with commit message `vX.X.X`
    - [ ] Create the git tag for the release with `git tag -a vX.X.X -m 'vX.X.X'`
    - [ ] Push the tags with `git push --tags`
    - [ ] Run `npm publish`

## Post-release checklist

Update version number in GL JS examples at [https://github.com/mapbox/mapbox-gl-js-docs](https://github.com/mapbox/mapbox-gl-js-docs):

    sed -i '' 's/mapbox-gl-geocoder\/v[^\/]*\//mapbox-gl-geocoder\/vX.X.X\//g' docs/pages/example/*.html
