### PR TITLE
Correct parameter list formating

### DIFF
--- a/API.md
+++ b/API.md
@@ -376,7 +376,8 @@ Subscribe to events that happen within the plugin.
 
 #### Parameters
 
--   `type` **[String][57]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
+-   `type` **[String][57]** name of event. Available events and the data passed into their respective event objects are:
+    -   **clear** `Emitted when the input is cleared`
     -   **loading** `{ query } Emitted when the geocoder is looking up a query`
     -   **results** `{ results } Fired when the geocoder returns a response`
     -   **result** `{ result } Fired when input is set`


### PR DESCRIPTION
Show the "clear" event on the "on" method parameters list with the correct formating.

This is just a small change to the API README.
When i was going through the documentation o noticed the format on the list was a bit off, and i even missed that "clear" was also an event.
So i just made the small correction to the markup

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
