### PR TITLE
Fix invalid geocoding requests

### DIFF
--- a/API.md
+++ b/API.md
@@ -86,7 +86,7 @@ A geocoder component using the [Mapbox Geocoding API][55]
     -   `options.types` **[string][57]?** a comma seperated list of types that filter
         results to match those specified. See [https://docs.mapbox.com/api/search/#data-types][65]
         for available types.
-        If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used.
+        If reverseGeocode is enabled and no type is specified, the type defaults to POIs. Otherwise, if you configure more than one type, the first type will be used.
     -   `options.minLength` **[Number][60]** Minimum number of characters to enter before results are shown. (optional, default `2`)
     -   `options.limit` **[Number][60]** Maximum number of results to show. (optional, default `5`)
     -   `options.language` **[string][57]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas. Defaults to the browser's language settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+- Prevents interpretation of forward geocoding requests as reverse geocoding requests [#424](https://github.com/mapbox/mapbox-gl-geocoder/pull/424)
+
 ## 4.7.1
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,14 @@ var MapboxEventManager = require('./events');
 var localization = require('./localization');
 var subtag = require('subtag');
 
+
+const GEOCODE_REQUEST_TYPE = {
+  FORWARD: 0,
+  LOCAL: 1,
+  REVERSE: 2,
+  INVALID: 3,
+};
+
 /**
  * A geocoder component using the [Mapbox Geocoding API](https://docs.mapbox.com/api/search/#geocoding)
  * @class MapboxGeocoder
@@ -37,7 +45,7 @@ var subtag = require('subtag');
  * @param {string} [options.types] a comma seperated list of types that filter
  * results to match those specified. See https://docs.mapbox.com/api/search/#data-types
  * for available types.
- * If reverseGeocode is enabled, you should specify one type. If you configure more than one type, the first type will be used.
+ * If reverseGeocode is enabled and no type is specified, the type defaults to POIs. Otherwise, if you configure more than one type, the first type will be used.
  * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas. Defaults to the browser's language settings.
@@ -380,7 +388,7 @@ MapboxGeocoder.prototype = {
           } else if (selected.geometry && selected.geometry.type && selected.geometry.type === 'Point' && selected.geometry.coordinates) {
             flyOptions.center = selected.geometry.coordinates;
           }
-          
+
           if (this._map){
             this._map.flyTo(flyOptions);
           }
@@ -401,12 +409,22 @@ MapboxGeocoder.prototype = {
     }
   },
 
-  _geocode: function(searchInput) {
-    this._loadingEl.style.display = 'block';
-    this._eventEmitter.emit('loading', { query: searchInput });
-    this.inputString = searchInput;
-    // Possible config proprerties to pass to client
-    var keys = [
+  _requestType: function(options, search) {
+    var type = GEOCODE_REQUEST_TYPE.INVALID;
+    const reverseGeocodeCoordRgx = /^[ ]*(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/;
+    if (options.localGeocoderOnly) {
+      type = GEOCODE_REQUEST_TYPE.LOCAL;
+    } else if (options.reverseGeocode && reverseGeocodeCoordRgx.test(search)) {
+      type = GEOCODE_REQUEST_TYPE.REVERSE;
+    } else {
+      type = GEOCODE_REQUEST_TYPE.FORWARD;
+    }
+    return type;
+  },
+
+  _setupConfig: function(requestType, search) {
+    // Possible config properties to pass to client
+    const keys = [
       'bbox',
       'limit',
       'proximity',
@@ -416,36 +434,37 @@ MapboxGeocoder.prototype = {
       'reverseMode',
       'mode'
     ];
-    var self = this;
-    var geocoderError = null;
-    // Create config object
-    var config = keys.reduce(function(config, key) {
-      if (self.options[key]) {
-        // countries, types, and language need to be passed in as arrays to client
-        // https://github.com/mapbox/mapbox-sdk-js/blob/master/services/geocoding.js#L38-L47
-        ['countries', 'types', 'language'].indexOf(key) > -1
-          ? (config[key] = self.options[key].split(/[\s,]+/))
-          : (config[key] = self.options[key]);
+    const spacesOrCommaRgx = /[\s,]+/;
 
-        if (key === 'proximity' && self.options[key] && typeof self.options[key].longitude === 'number' && typeof self.options[key].latitude === 'number') {
-          config[key] = [self.options[key].longitude, self.options[key].latitude]
-        }
+    var self = this;
+    var config = keys.reduce(function(config, key) {
+      if (!self.options[key]) {
+        return config;
       }
+
+      // countries, types, and language need to be passed in as arrays to client
+      // https://github.com/mapbox/mapbox-sdk-js/blob/master/services/geocoding.js#L38-L47
+      ['countries', 'types', 'language'].indexOf(key) > -1
+        ? (config[key] = self.options[key].split(spacesOrCommaRgx))
+        : (config[key] = self.options[key]);
+
+      const isCoordKey =
+        typeof self.options[key].longitude === 'number' &&
+        typeof self.options[key].latitude  === 'number';
+
+      if (key === 'proximity' && isCoordKey) {
+        const lng = self.options[key].longitude;
+        const lat = self.options[key].latitude;
+
+        config[key] = [lng, lat];
+      }
+
       return config;
     }, {});
 
-    var request;
-    if (this.options.localGeocoderOnly){
-      request = Promise.resolve();
-    }
-    // check if searchInput resembles coordinates, and if it does,
-    // make the request a reverseGeocode
-    else if (
-      this.options.reverseGeocode &&
-      /(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/.test(searchInput)
-    ) {
-      // parse coordinates
-      var coords = searchInput.split(/[\s(,)?]+/).map(function(c) {
+    switch (requestType) {
+    case GEOCODE_REQUEST_TYPE.REVERSE: {
+      var coords = search.split(spacesOrCommaRgx).map(function(c) {
         return parseFloat(c, 10);
       }).reverse();
 
@@ -454,29 +473,59 @@ MapboxGeocoder.prototype = {
       config.types ? [config.types[0]] : ["poi"];
       config = extend(config, { query: coords, limit: 1 });
 
-      // drop proximity which may have been set by trackProximity since it's not supported by the reverseGeocoder
+      // drop proximity which may have been set by trackProximity
+      // since it's not supported by the reverseGeocoder
       if ('proximity' in config) {
         delete config.proximity;
       }
-
-      request = this.geocoderService.reverseGeocode(config).send();
-    } else {
-      config = extend(config, { query: searchInput });
-      request = this.geocoderService.forwardGeocode(config).send();
-    }
-
-    var localGeocoderRes = [];
-    if (this.options.localGeocoder) {
-      localGeocoderRes = this.options.localGeocoder(searchInput);
-      if (!localGeocoderRes) {
-        localGeocoderRes = [];
+    } break;
+    case GEOCODE_REQUEST_TYPE.FORWARD: {
+      // Ensure that any reverse geocoding looking request is cleaned up
+      // to be processed as only a forward geocoding request by the server.
+      const reverseGeocodeCoordRgx = /^[ ]*(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)*[ ]*$/;
+      if (reverseGeocodeCoordRgx.test(search)) {
+        search = search.replace(/,/g, ' ');
       }
+      config = extend(config, { query: search });
+    } break;
     }
+
+    return config;
+  },
+
+  _geocode: function(searchInput) {
+    this.inputString = searchInput;
+    this._loadingEl.style.display = 'block';
+    this._eventEmitter.emit('loading', { query: searchInput });
+
+    const requestType = this._requestType(this.options, searchInput);
+    const config = this._setupConfig(requestType, searchInput);
+
+    var request;
+    switch (requestType) {
+    case GEOCODE_REQUEST_TYPE.LOCAL:
+      request = Promise.resolve();
+      break;
+    case GEOCODE_REQUEST_TYPE.FORWARD:
+      request = this.geocoderService.forwardGeocode(config).send();
+      break;
+    case GEOCODE_REQUEST_TYPE.REVERSE:
+      request = this.geocoderService.reverseGeocode(config).send();
+      break;
+    case GEOCODE_REQUEST_TYPE.INVALID:
+      // Clear UI results if any
+      this._renderNoResults();
+      this._loadingEl.style.display = 'none';
+      return Promise.resolve();
+    }
+
+    var localGeocoderRes = this.options.localGeocoder ? this.options.localGeocoder(searchInput) || [] : [];
     var externalGeocoderRes = [];
 
-    request.catch(function(error){
+    var geocoderError = null;
+    request.catch(function(error) {
       geocoderError = error;
-    }.bind(this)) 
+    }.bind(this))
       .then(
         function(response) {
           this._loadingEl.style.display = 'none';

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,6 @@ const GEOCODE_REQUEST_TYPE = {
   FORWARD: 0,
   LOCAL: 1,
   REVERSE: 2,
-  INVALID: 3,
 };
 
 /**
@@ -410,7 +409,7 @@ MapboxGeocoder.prototype = {
   },
 
   _requestType: function(options, search) {
-    var type = GEOCODE_REQUEST_TYPE.INVALID;
+    var type;
     const reverseGeocodeCoordRgx = /^[ ]*(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)[ ]*$/;
     if (options.localGeocoderOnly) {
       type = GEOCODE_REQUEST_TYPE.LOCAL;
@@ -512,11 +511,6 @@ MapboxGeocoder.prototype = {
     case GEOCODE_REQUEST_TYPE.REVERSE:
       request = this.geocoderService.reverseGeocode(config).send();
       break;
-    case GEOCODE_REQUEST_TYPE.INVALID:
-      // Clear UI results if any
-      this._renderNoResults();
-      this._loadingEl.style.display = 'none';
-      return Promise.resolve();
     }
 
     var localGeocoderRes = this.options.localGeocoder ? this.options.localGeocoder(searchInput) || [] : [];

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -1040,7 +1040,6 @@ test('geocoder', function(tt) {
   });
 
   tt.test('error is shown after an error occurred [with local geocoder]', function(t){
-    // debugger; // eslint-disable-line no-debugger
     setup({
       localGeocoder: function(){
         return [

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -179,19 +179,13 @@ test('geocoder', function(tt) {
   });
 
   tt.test('options.reverseGeocode - false by default', function(t) {
-    t.plan(2);
+    t.plan(1);
     setup();
     geocoder.query('-6.1933875, 34.5177548');
     geocoder.on(
       'results',
       once(function(e) {
         t.equal(e.features.length, 0, 'No results returned');
-      })
-    );
-    geocoder.on(
-      'error',
-      once(function(e) {
-        t.equal(e.error.statusCode, 422, 'should error');
       })
     );
   });
@@ -273,10 +267,37 @@ test('geocoder', function(tt) {
   });
 
   tt.test('options.localGeocoder', function(t) {
-    t.plan(3);
+    t.plan(2);
     setup({
       flyTo: false,
       limit: 6,
+      localGeocoder: function(q) {
+        return [q];
+      }
+    });
+
+    geocoder.query('London');
+    geocoder.on(
+      'results',
+      once(function(e) {
+        t.equal(
+          e.features.length,
+          7,
+          'Local geocoder supplement remote response'
+        );
+        t.equal(
+          e.features[0],
+          'London',
+          'Local geocoder results above remote response'
+        );
+      })
+    );
+  });
+
+  tt.test('options.localGeocoder with reverseGeocode=true', function(t) {
+    setup({
+      flyTo: false,
+      reverseGeocode: true,
       localGeocoder: function(q) {
         return [q];
       }
@@ -286,31 +307,9 @@ test('geocoder', function(tt) {
     geocoder.on(
       'results',
       once(function(e) {
-        t.equal(e.features.length, 1, 'Local geocoder used');
-
-        geocoder.query('London');
-        geocoder.on(
-          'results',
-          once(function(e) {
-            t.equal(
-              e.features.length,
-              7,
-              'Local geocoder supplement remote response'
-            );
-
-            geocoder.query('London');
-            geocoder.on(
-              'results',
-              once(function(e) {
-                t.equal(
-                  e.features[0],
-                  'London',
-                  'Local geocoder results above remote response'
-                );
-              })
-            );
-          })
-        );
+        t.equal(e.features.length, 2, 'Local geocoder used');
+        t.equal(e.features[0], '-30,150', 'Local geocoder supplement remote response');
+        t.end();
       })
     );
   });
@@ -324,7 +323,7 @@ test('geocoder', function(tt) {
         return Promise.resolve([
           {
             "id":"place.7673410831246050",
-            "type":"Feature", 
+            "type":"Feature",
             "place_name":"Promise: Washington, District of Columbia, United States of America",
             "geometry":{"type":"Point","coordinates":[-77.0366,38.895]}
           }
@@ -769,7 +768,7 @@ test('geocoder', function(tt) {
     geocoder.query('high');
     geocoder.on(
       'result',
-      once(function() {  
+      once(function() {
         t.ok(markerConstructorSpy.calledOnce, "a new marker is added to the map");
         var calledWithOptions = markerConstructorSpy.args[0][0];
         t.equals(calledWithOptions.color, '#4668F2', 'a default color is set');
@@ -794,7 +793,7 @@ test('geocoder', function(tt) {
     geocoder.query('high');
     geocoder.on(
       'result',
-      once(function() {  
+      once(function() {
         t.ok(markerConstructorSpy.calledOnce, "a new marker is added to the map");
         var calledWithOptions = markerConstructorSpy.args[0][0];
         t.equals(calledWithOptions.color, 'purple', "sets the correct color property");
@@ -816,7 +815,7 @@ test('geocoder', function(tt) {
     geocoder.query('high');
     geocoder.on(
       'result',
-      once(function() {  
+      once(function() {
         t.ok(markerConstructorSpy.notCalled, "a new marker is not added to the map");
         markerConstructorSpy.restore();
       })
@@ -978,7 +977,7 @@ test('geocoder', function(tt) {
     geocoder.query('high');
     geocoder.on(
       'result',
-      once(function() {  
+      once(function() {
         setTimeout(function() {
           t.notEqual(geocoder._typeahead.data.length, 0, 'the suggestions menu has some options in it after a query');
           geocoder._renderMessage("<h1>This is a test</h1>");
@@ -1000,7 +999,7 @@ test('geocoder', function(tt) {
     geocoder.query('high');
     geocoder.on(
       'result',
-      once(function() {  
+      once(function() {
         geocoder._renderError();
         t.ok(renderMessageSpy.calledOnce, 'the error render method calls the renderMessage method exactly once');
         var calledWithArgs = renderMessageSpy.args[0][0];
@@ -1017,7 +1016,7 @@ test('geocoder', function(tt) {
     geocoder.query('high');
     geocoder.on(
       'result',
-      once(function() {  
+      once(function() {
         geocoder._renderNoResults();
         t.ok(renderMessageSpy.calledOnce, 'the no results render method calls the renderMessage method exactly once');
         var calledWithArgs = renderMessageSpy.args[0][0];
@@ -1030,21 +1029,18 @@ test('geocoder', function(tt) {
 
   tt.test('error is shown after an error occurred', function(t){
     setup({});
-    var renderMessageSpy = sinon.spy(geocoder, '_renderMessage');
-    geocoder.query('12,'); //this will cause a 422 error
+    geocoder.query('12,');
     geocoder.on(
-      'error',
-      once(function() {  
-        t.ok(renderMessageSpy.calledOnce, 'an error was rendered');
-        var calledWithArgs = renderMessageSpy.args[0][0];
-        t.ok(calledWithArgs.indexOf('mapbox-gl-geocoder--error') > -1, 'the info message specifies the correct class');
-        t.ok(calledWithArgs.indexOf('There was an error reaching the server') > -1, 'the info message specifies the correct message');
+      'results',
+      once(function(e) {
+        t.ok(e.features.length > 0, 'Some results are returned using and the input is not used for reverse geocoding');
         t.end();
       })
     );
   });
 
   tt.test('error is shown after an error occurred [with local geocoder]', function(t){
+    // debugger; // eslint-disable-line no-debugger
     setup({
       localGeocoder: function(){
         return [
@@ -1052,12 +1048,11 @@ test('geocoder', function(tt) {
         ];
       }
     });
-    var renderErrorSpy = sinon.spy(geocoder, '_renderError');
-    geocoder.query('12,'); //this will cause a 422 error
+    geocoder.query('12,');
     geocoder.on(
-      'error',
-      once(function() {  
-        t.notOk(renderErrorSpy.called, 'the error message is not rendered when the local geocoder returns successfully')
+      'results',
+      once(function(e) {
+        t.ok(e.features.length > 0, 'Some results are returned using and the input is not used for reverse geocoding');
         t.end();
       })
     );
@@ -1066,16 +1061,15 @@ test('geocoder', function(tt) {
   tt.test('message is shown if no results are returned', function(t){
     setup({});
     var renderMessageSpy = sinon.spy(geocoder, '_renderNoResults');
-    geocoder.query('abcdefghijkl'); //this will return no results
+    geocoder.query('abcdefghijkl!@#$%^&*()_+'); //this will return no results
     geocoder.on(
       'results',
-      once(function() {  
+      once(function() {
         t.ok(renderMessageSpy.called, 'a message was rendered');
         t.end();
       })
     );
   });
-
 
   tt.test('no mapbox api call is made if localGeocoderOnly is set', function(t){
     setup({
@@ -1096,7 +1090,7 @@ test('geocoder', function(tt) {
     geocoder.query('Golden Gate Bridge');
     geocoder.on(
       'results',
-      once(function(e) {  
+      once(function(e) {
         t.ok(
           e.features[0].place_name == "Golden Gate Bridge",
           'returns the result of the local geocoder'
@@ -1152,7 +1146,7 @@ test('geocoder', function(tt) {
     setup();
     var searchMock = sinon.spy(geocoder, "_geocode")
     var event = new ClipboardEvent('paste', {
-      dataType: 'text/plain', 
+      dataType: 'text/plain',
       data: 'Golden Gate Bridge'
     })
     geocoder._onPaste(event);
@@ -1169,7 +1163,7 @@ test('geocoder', function(tt) {
     });
     var searchMock = sinon.spy(geocoder, "_geocode")
     var event = new ClipboardEvent('paste', {
-      dataType: 'text/plain', 
+      dataType: 'text/plain',
       data: 'abc'
     })
     geocoder._onPaste(event);
@@ -1182,7 +1176,7 @@ test('geocoder', function(tt) {
     setup();
     var searchMock = sinon.spy(geocoder, "_geocode")
     var event = new ClipboardEvent('paste', {
-      dataType: 'text/plain', 
+      dataType: 'text/plain',
       data: ''
     })
     geocoder._onPaste(event);


### PR DESCRIPTION
This PR prevents forward geocoding requests to be interpreted as reverse geocoding requests.

Reminder on the accepted inputs from the server:
```
/geocoding/v5/{endpoint}/{longitude},{latitude}.json
```
```
/geocoding/v5/{endpoint}/{search_text}.json
```
Refer https://docs.mapbox.com/api/search/geocoding/#reverse-geocoding.

In the proposed PR, the geocoder follows this behavior:
- If `reverseGeocode=true`:
  - If the request is well-formed, it will be interpreted as a reverse geocoding request, and as a forward geocoding request otherwise.
- If `reverseGeocode=false`:
  - If the request is the start of a reverse geocoding request `number,number?`, or a valid geocoding request `number,number`, it will be transformed in order for the server to not interpret it as a reverse geocoding request (using comma trimming, as `12,` is equivalent to `12 ` when doing forward geocoding through this API). This effectively prevents 422 responses from the server for a user typing the start of an address with a number and a comma. 422 responses are the result of a forward geocoding request not being fully configured and falling through the `/{longitude},{latitude}.json` API syntax.

This also makes the option `reverseGeocode` intent more clear, meaning that no reverse geocode request may accidentally be interpreted as a forward geocoding request.

Fixes #274, #352, #408

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
