### PR TITLE
Add option to display suggestion on setInput

### DIFF
--- a/API.md
+++ b/API.md
@@ -185,8 +185,8 @@ Set input
 
 #### Parameters
 
-*   `searchInput` **[string][57]** location name or other search input
--   `showSuggestions` **[boolean][61]** display suggestion on setInput call (optional, default `false`)
+*   `searchInput` **[string][76]** location name or other search input
+-   `showSuggestions` **[boolean][80]** display suggestion on setInput call (optional, default `false`)
 
 Returns **[MapboxGeocoder][2]** this
 

--- a/API.md
+++ b/API.md
@@ -185,7 +185,8 @@ Set input
 
 #### Parameters
 
-*   `searchInput` **[string][76]** location name or other search input
+*   `searchInput` **[string][57]** location name or other search input
+-   `showSuggestions` **[boolean][61]** display suggestion on setInput call (optional, default `false`)
 
 Returns **[MapboxGeocoder][2]** this
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -939,10 +939,9 @@ MapboxGeocoder.prototype = {
     this._inputEl.value = searchInput;
     this._typeahead.selected = null;
     this._typeahead.clear();
-    if (showSuggestions && searchInput.length >= this.options.minLength) {
-      this._geocode(searchInput);
-    } else if (!showSuggestions) {
-      this._onChange();
+    if (searchInput.length >= this.options.minLength) {
+      showSuggestions ? this._geocode(searchInput) : this._onChange();
+    }
     }
     return this;
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -931,7 +931,10 @@ MapboxGeocoder.prototype = {
    * @param {boolean} [showSuggestions=false] display suggestion on setInput call
    * @returns {MapboxGeocoder} this
    */
-  setInput: function(searchInput, showSuggestions = true) {
+  setInput: function(searchInput, showSuggestions) {
+    if (showSuggestions === undefined) {
+      showSuggestions = false
+    }
     // Set input value to passed value and clear everything else.
     this._inputEl.value = searchInput;
     this._typeahead.selected = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -928,15 +928,18 @@ MapboxGeocoder.prototype = {
   /**
    * Set input
    * @param {string} searchInput location name or other search input
+   * @param {boolean} [showSuggestions=false] display suggestion on setInput call
    * @returns {MapboxGeocoder} this
    */
-  setInput: function(searchInput) {
+  setInput: function(searchInput, showSuggestions = true) {
     // Set input value to passed value and clear everything else.
     this._inputEl.value = searchInput;
     this._typeahead.selected = null;
     this._typeahead.clear();
-    if (searchInput.length >= this.options.minLength) {
+    if (showSuggestions && searchInput.length >= this.options.minLength) {
       this._geocode(searchInput);
+    } else if (!showSuggestions) {
+      this._onChange();
     }
     return this;
   },


### PR DESCRIPTION
Add an optional parameter to choose whether to display the suggestion or not when using `setInput`

`setInput` used to not show the suggestions but is has been updated in https://github.com/mapbox/mapbox-gl-geocoder/pull/345 without a possibility to have the same behaviour than before. As stated by https://github.com/mapbox/mapbox-gl-geocoder/pull/345#issuecomment-804175282 it feels more like a breaking change than an improvement.

In this issue we can see the behaviour difference https://github.com/mapbox/mapbox-gl-geocoder/issues/401 .