### PR TITLE
Add manual search debounce option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,8 @@ MapboxGeocoder.prototype = {
     render: function(item) {
       var placeName = item.place_name.split(',');
       return '<div class="mapboxgl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title">' + placeName[0]+ '</div><div class="mapboxgl-ctrl-geocoder--suggestion-address">' + placeName.splice(1, placeName.length).join(',') + '</div></div>';
-    }
+    },
+    debounceSearch: 200,
   },
 
   /**
@@ -210,7 +211,7 @@ MapboxGeocoder.prototype = {
       this._inputEl.addEventListener('blur', this._onBlur);
     }
 
-    this._inputEl.addEventListener('keydown', debounce(this._onKeyDown, 200));
+    this._inputEl.addEventListener('keydown', debounce(this._onKeyDown, this.debounceSearch));
     this._inputEl.addEventListener('paste', this._onPaste);
     this._inputEl.addEventListener('change', this._onChange);
     this.container.addEventListener('mouseenter', this._showButton);


### PR DESCRIPTION
I have added a minor addition that allows for a manual debounce before sending a search query. If unset, the default option of 200ms is preserved.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
