### PR TITLE
Add geolocate functionality to mapbox-gl-geocoder

### DIFF
--- a/API.md
+++ b/API.md
@@ -70,52 +70,58 @@
         -   [Parameters][66]
     -   [off][67]
         -   [Parameters][68]
+-   [transformFeatureToGeolocationText][69]
+    -   [Parameters][70]
+-   [getAddressInfo][71]
+    -   [Parameters][72]
 
 ## MapboxGeocoder
 
-A geocoder component using the [Mapbox Geocoding API][69]
+A geocoder component using the [Mapbox Geocoding API][73]
 
 ### Parameters
 
--   `options` **[Object][70]** 
-    -   `options.accessToken` **[String][71]** Required.
-    -   `options.origin` **[String][71]** Use to set a custom API origin. (optional, default `https://api.mapbox.com`)
-    -   `options.mapboxgl` **[Object][70]?** A [mapbox-gl][72] instance to use when creating [Markers][73]. Required if `options.marker` is `true`.
-    -   `options.zoom` **[Number][74]** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
-    -   `options.flyTo` **([Boolean][75] \| [Object][70])** If `false`, animating the map to a selected result is disabled. If `true`, animating the map will use the default animation parameters. If an object, it will be passed as `options` to the map [`flyTo`][76] or [`fitBounds`][77] method providing control over the animation of the transition. (optional, default `true`)
-    -   `options.placeholder` **[String][71]** Override the default placeholder attribute value. (optional, default `Search`)
-    -   `options.proximity` **([Object][70] \| `"ip"`)?** a geographical point given as an object with `latitude` and `longitude` properties, or the string 'ip' to use a user's IP address location. Search results closer to this point will be given higher priority.
-    -   `options.trackProximity` **[Boolean][75]** If `true`, the geocoder proximity will dynamically update based on the current map view or user's IP location, depending on zoom level. (optional, default `true`)
-    -   `options.collapsed` **[Boolean][75]** If `true`, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
-    -   `options.clearAndBlurOnEsc` **[Boolean][75]** If `true`, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
-    -   `options.clearOnBlur` **[Boolean][75]** If `true`, the geocoder control will clear its value when the input blurs. (optional, default `false`)
-    -   `options.bbox` **[Array][78]?** a bounding box argument: this is
+-   `options` **[Object][74]** 
+    -   `options.accessToken` **[String][75]** Required.
+    -   `options.origin` **[String][75]** Use to set a custom API origin. (optional, default `https://api.mapbox.com`)
+    -   `options.mapboxgl` **[Object][74]?** A [mapbox-gl][76] instance to use when creating [Markers][77]. Required if `options.marker` is `true`.
+    -   `options.zoom` **[Number][78]** On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`. (optional, default `16`)
+    -   `options.flyTo` **([Boolean][79] \| [Object][74])** If `false`, animating the map to a selected result is disabled. If `true`, animating the map will use the default animation parameters. If an object, it will be passed as `options` to the map [`flyTo`][80] or [`fitBounds`][81] method providing control over the animation of the transition. (optional, default `true`)
+    -   `options.placeholder` **[String][75]** Override the default placeholder attribute value. (optional, default `Search`)
+    -   `options.proximity` **([Object][74] \| `"ip"`)?** a geographical point given as an object with `latitude` and `longitude` properties, or the string 'ip' to use a user's IP address location. Search results closer to this point will be given higher priority.
+    -   `options.trackProximity` **[Boolean][79]** If `true`, the geocoder proximity will dynamically update based on the current map view or user's IP location, depending on zoom level. (optional, default `true`)
+    -   `options.collapsed` **[Boolean][79]** If `true`, the geocoder control will collapse until hovered or in focus. (optional, default `false`)
+    -   `options.clearAndBlurOnEsc` **[Boolean][79]** If `true`, the geocoder control will clear it's contents and blur when user presses the escape key. (optional, default `false`)
+    -   `options.clearOnBlur` **[Boolean][79]** If `true`, the geocoder control will clear its value when the input blurs. (optional, default `false`)
+    -   `options.bbox` **[Array][82]?** a bounding box argument: this is
         a bounding box given as an array in the format `[minX, minY, maxX, maxY]`.
         Search results will be limited to the bounding box.
-    -   `options.countries` **[string][71]?** a comma separated list of country codes to
+    -   `options.countries` **[string][75]?** a comma separated list of country codes to
         limit results to specified country or countries.
-    -   `options.types` **[string][71]?** a comma seperated list of types that filter
-        results to match those specified. See [https://docs.mapbox.com/api/search/#data-types][79]
+    -   `options.types` **[string][75]?** a comma seperated list of types that filter
+        results to match those specified. See [https://docs.mapbox.com/api/search/#data-types][83]
         for available types.
         If reverseGeocode is enabled and no type is specified, the type defaults to POIs. Otherwise, if you configure more than one type, the first type will be used.
-    -   `options.minLength` **[Number][74]** Minimum number of characters to enter before results are shown. (optional, default `2`)
-    -   `options.limit` **[Number][74]** Maximum number of results to show. (optional, default `5`)
-    -   `options.language` **[string][71]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas. Defaults to the browser's language settings.
-    -   `options.filter` **[Function][80]?** A function which accepts a Feature in the [Carmen GeoJSON][81] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
-    -   `options.localGeocoder` **[Function][80]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON][81] format.
-    -   `options.externalGeocoder` **[Function][80]?** A function accepting the query string and current features list which performs geocoding to supplement results from the Mapbox Geocoding API. Expected to return a Promise which resolves to an Array of GeoJSON Features in the [Carmen GeoJSON][81] format.
+    -   `options.minLength` **[Number][78]** Minimum number of characters to enter before results are shown. (optional, default `2`)
+    -   `options.limit` **[Number][78]** Maximum number of results to show. (optional, default `5`)
+    -   `options.language` **[string][75]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas. Defaults to the browser's language settings.
+    -   `options.filter` **[Function][84]?** A function which accepts a Feature in the [Carmen GeoJSON][85] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+    -   `options.localGeocoder` **[Function][84]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON][85] format.
+    -   `options.externalGeocoder` **[Function][84]?** A function accepting the query string and current features list which performs geocoding to supplement results from the Mapbox Geocoding API. Expected to return a Promise which resolves to an Array of GeoJSON Features in the [Carmen GeoJSON][85] format.
     -   `options.reverseMode` **(distance | score)** Set the factors that are used to sort nearby results. (optional, default `distance`)
-    -   `options.reverseGeocode` **[boolean][75]** If `true`, enable reverse geocoding mode. In reverse geocoding, search input is expected to be coordinates in the form `lat, lon`, with suggestions being the reverse geocodes. (optional, default `false`)
-    -   `options.enableEventLogging` **[Boolean][75]** Allow Mapbox to collect anonymous usage statistics from the plugin. (optional, default `true`)
-    -   `options.marker` **([Boolean][75] \| [Object][70])** If `true`, a [Marker][73] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
-    -   `options.render` **[Function][80]?** A function that specifies how the results should be rendered in the dropdown menu. This function should accepts a single [Carmen GeoJSON][81] object as input and return a string. Any HTML in the returned string will be rendered.
-    -   `options.getItemValue` **[Function][80]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][81] object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
-    -   `options.mode` **[String][71]** A string specifying the geocoding [endpoint][82] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `mapbox.places`)
-    -   `options.localGeocoderOnly` **[Boolean][75]** If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Mapbox API with the `localGeocoder` results ranked higher. (optional, default `false`)
-    -   `options.autocomplete` **[Boolean][75]** Specify whether to return autocomplete results or not. When autocomplete is enabled, results will be included that start with the requested string, rather than just responses that match it exactly. (optional, default `true`)
-    -   `options.fuzzyMatch` **[Boolean][75]** Specify whether the Geocoding API should attempt approximate, as well as exact, matching when performing searches, or whether it should opt out of this behavior and only attempt exact matching. (optional, default `true`)
-    -   `options.routing` **[Boolean][75]** Specify whether to request additional metadata about the recommended navigation destination corresponding to the feature or not. Only applicable for address features. (optional, default `false`)
-    -   `options.worldview` **[String][71]** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups. (optional, default `"us"`)
+    -   `options.reverseGeocode` **[boolean][79]** If `true`, enable reverse geocoding mode. In reverse geocoding, search input is expected to be coordinates in the form `lat, lon`, with suggestions being the reverse geocodes. (optional, default `false`)
+    -   `options.enableEventLogging` **[Boolean][79]** Allow Mapbox to collect anonymous usage statistics from the plugin. (optional, default `true`)
+    -   `options.marker` **([Boolean][79] \| [Object][74])** If `true`, a [Marker][77] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
+    -   `options.render` **[Function][84]?** A function that specifies how the results should be rendered in the dropdown menu. This function should accepts a single [Carmen GeoJSON][85] object as input and return a string. Any HTML in the returned string will be rendered.
+    -   `options.getItemValue` **[Function][84]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][85] object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
+    -   `options.mode` **[String][75]** A string specifying the geocoding [endpoint][86] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `mapbox.places`)
+    -   `options.localGeocoderOnly` **[Boolean][79]** If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Mapbox API with the `localGeocoder` results ranked higher. (optional, default `false`)
+    -   `options.autocomplete` **[Boolean][79]** Specify whether to return autocomplete results or not. When autocomplete is enabled, results will be included that start with the requested string, rather than just responses that match it exactly. (optional, default `true`)
+    -   `options.fuzzyMatch` **[Boolean][79]** Specify whether the Geocoding API should attempt approximate, as well as exact, matching when performing searches, or whether it should opt out of this behavior and only attempt exact matching. (optional, default `true`)
+    -   `options.routing` **[Boolean][79]** Specify whether to request additional metadata about the recommended navigation destination corresponding to the feature or not. Only applicable for address features. (optional, default `false`)
+    -   `options.worldview` **[String][75]** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups. (optional, default `"us"`)
+    -   `options.enableGeolocation` **[Boolean][79]** If `true` enable user geolocation feature. (optional, default `false`)
+    -   `options.addressAccuracy` **(`"address"` \| `"street"` \| `"place"` \| `"country"`)** The accuracy for the geolocation feature with which we define the address line to fill. The browser API returns the user's position with accuracy, and sometimes we can get the neighbor's address. To prevent receiving an incorrect address, you can reduce the accuracy of the definition. (optional, default `"street"`)
 
 ### Examples
 
@@ -124,15 +130,15 @@ var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
 map.addControl(geocoder);
 ```
 
-Returns **[MapboxGeocoder][83]** `this`
+Returns **[MapboxGeocoder][87]** `this`
 
 ### addTo
 
 Add the geocoder to a container. The container can be either a `mapboxgl.Map`, an `HTMLElement` or a CSS selector string.
 
-If the container is a [`mapboxgl.Map`][84], this function will behave identically to [`Map.addControl(geocoder)`][85].
-If the container is an instance of [`HTMLElement`][86], then the geocoder will be appended as a child of that [`HTMLElement`][86].
-If the container is a [CSS selector string][87], the geocoder will be appended to the element returned from the query.
+If the container is a [`mapboxgl.Map`][88], this function will behave identically to [`Map.addControl(geocoder)`][89].
+If the container is an instance of [`HTMLElement`][90], then the geocoder will be appended as a child of that [`HTMLElement`][90].
+If the container is a [CSS selector string][91], the geocoder will be appended to the element returned from the query.
 
 This function will throw an error if the container is none of the above.
 It will also throw an error if the referenced HTML element cannot be found in the `document.body`.
@@ -146,7 +152,7 @@ geocoder.addTo('#geocoder-container');
 
 #### Parameters
 
--   `container` **([String][71] \| [HTMLElement][88] | mapboxgl.Map)** A reference to the container to which to add the geocoder
+-   `container` **([String][75] \| [HTMLElement][92] | mapboxgl.Map)** A reference to the container to which to add the geocoder
 
 ### clear
 
@@ -154,7 +160,7 @@ Clear and then focus the input.
 
 #### Parameters
 
--   `ev` **[Event][89]?** the event that triggered the clear, if available
+-   `ev` **[Event][93]?** the event that triggered the clear, if available
 
 ### query
 
@@ -162,9 +168,9 @@ Set & query the input
 
 #### Parameters
 
--   `searchInput` **[string][71]** location name or other search input
+-   `searchInput` **[string][75]** location name or other search input
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### setInput
 
@@ -172,9 +178,9 @@ Set input
 
 #### Parameters
 
--   `searchInput` **[string][71]** location name or other search input
+-   `searchInput` **[string][75]** location name or other search input
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### setProximity
 
@@ -182,16 +188,16 @@ Set proximity
 
 #### Parameters
 
--   `proximity` **([Object][70] \| `"ip"`)** The new `options.proximity` value. This is a geographical point given as an object with `latitude` and `longitude` properties or the string 'ip'.
--   `disableTrackProximity` **[Boolean][75]** If true, sets `trackProximity` to false. True by default to prevent `trackProximity` from unintentionally overriding an explicitly set proximity value. (optional, default `true`)
+-   `proximity` **([Object][74] \| `"ip"`)** The new `options.proximity` value. This is a geographical point given as an object with `latitude` and `longitude` properties or the string 'ip'.
+-   `disableTrackProximity` **[Boolean][79]** If true, sets `trackProximity` to false. True by default to prevent `trackProximity` from unintentionally overriding an explicitly set proximity value. (optional, default `true`)
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getProximity
 
 Get proximity
 
-Returns **[Object][70]** The geocoder proximity
+Returns **[Object][74]** The geocoder proximity
 
 ### setRenderFunction
 
@@ -199,15 +205,15 @@ Set the render function used in the results dropdown
 
 #### Parameters
 
--   `fn` **[Function][80]** The function to use as a render function. This function accepts a single [Carmen GeoJSON][81] object as input and returns a string.
+-   `fn` **[Function][84]** The function to use as a render function. This function accepts a single [Carmen GeoJSON][85] object as input and returns a string.
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getRenderFunction
 
 Get the function used to render the results dropdown
 
-Returns **[Function][80]** the render function
+Returns **[Function][84]** the render function
 
 ### setLanguage
 
@@ -217,21 +223,21 @@ Look first at the explicitly set options otherwise use the browser's language se
 
 #### Parameters
 
--   `language` **[String][71]** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
+-   `language` **[String][75]** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas.
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getLanguage
 
 Get the language to use in UI elements and when making search requests
 
-Returns **[String][71]** The language(s) used by the plugin, if any
+Returns **[String][75]** The language(s) used by the plugin, if any
 
 ### getZoom
 
 Get the zoom level the map will move to when there is no bounding box on the selected result
 
-Returns **[Number][74]** the map zoom
+Returns **[Number][78]** the map zoom
 
 ### setZoom
 
@@ -239,15 +245,15 @@ Set the zoom level
 
 #### Parameters
 
--   `zoom` **[Number][74]** The zoom level that the map should animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
+-   `zoom` **[Number][78]** The zoom level that the map should animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getFlyTo
 
 Get the parameters used to fly to the selected response, if any
 
-Returns **([Boolean][75] \| [Object][70])** The `flyTo` option
+Returns **([Boolean][79] \| [Object][74])** The `flyTo` option
 
 ### setFlyTo
 
@@ -255,13 +261,13 @@ Set the flyTo options
 
 #### Parameters
 
--   `flyTo` **([Boolean][75] \| [Object][70])** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, it will be passed as `options` to the map [`flyTo`][76] or [`fitBounds`][77] method providing control over the animation of the transition.
+-   `flyTo` **([Boolean][79] \| [Object][74])** If false, animating the map to a selected result is disabled. If true, animating the map will use the default animation parameters. If an object, it will be passed as `options` to the map [`flyTo`][80] or [`fitBounds`][81] method providing control over the animation of the transition.
 
 ### getPlaceholder
 
 Get the value of the placeholder string
 
-Returns **[String][71]** The input element's placeholder value
+Returns **[String][75]** The input element's placeholder value
 
 ### setPlaceholder
 
@@ -269,15 +275,15 @@ Set the value of the input element's placeholder
 
 #### Parameters
 
--   `placeholder` **[String][71]** the text to use as the input element's placeholder
+-   `placeholder` **[String][75]** the text to use as the input element's placeholder
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getBbox
 
 Get the bounding box used by the plugin
 
-Returns **[Array][78]&lt;[Number][74]>** the bounding box, if any
+Returns **[Array][82]&lt;[Number][78]>** the bounding box, if any
 
 ### setBbox
 
@@ -285,15 +291,15 @@ Set the bounding box to limit search results to
 
 #### Parameters
 
--   `bbox` **[Array][78]&lt;[Number][74]>** a bounding box given as an array in the format [minX, minY, maxX, maxY].
+-   `bbox` **[Array][82]&lt;[Number][78]>** a bounding box given as an array in the format [minX, minY, maxX, maxY].
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getCountries
 
 Get a list of the countries to limit search results to
 
-Returns **[String][71]** a comma separated list of countries to limit to, if any
+Returns **[String][75]** a comma separated list of countries to limit to, if any
 
 ### setCountries
 
@@ -301,15 +307,15 @@ Set the countries to limit search results to
 
 #### Parameters
 
--   `countries` **[String][71]** a comma separated list of countries to limit to
+-   `countries` **[String][75]** a comma separated list of countries to limit to
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getTypes
 
 Get a list of the types to limit search results to
 
-Returns **[String][71]** a comma separated list of types to limit to
+Returns **[String][75]** a comma separated list of types to limit to
 
 ### setTypes
 
@@ -318,15 +324,15 @@ Set the types to limit search results to
 #### Parameters
 
 -   `types`  
--   `countries` **[String][71]** a comma separated list of types to limit to
+-   `countries` **[String][75]** a comma separated list of types to limit to
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getMinLength
 
 Get the minimum number of characters typed to trigger results used in the plugin
 
-Returns **[Number][74]** The minimum length in characters before a search is triggered
+Returns **[Number][78]** The minimum length in characters before a search is triggered
 
 ### setMinLength
 
@@ -334,15 +340,15 @@ Set the minimum number of characters typed to trigger results used by the plugin
 
 #### Parameters
 
--   `minLength` **[Number][74]** the minimum length in characters
+-   `minLength` **[Number][78]** the minimum length in characters
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getLimit
 
 Get the limit value for the number of results to display used by the plugin
 
-Returns **[Number][74]** The limit value for the number of results to display used by the plugin
+Returns **[Number][78]** The limit value for the number of results to display used by the plugin
 
 ### setLimit
 
@@ -350,15 +356,15 @@ Set the limit value for the number of results to display used by the plugin
 
 #### Parameters
 
--   `limit` **[Number][74]** the number of search results to return
+-   `limit` **[Number][78]** the number of search results to return
 
-Returns **[MapboxGeocoder][83]** 
+Returns **[MapboxGeocoder][87]** 
 
 ### getFilter
 
 Get the filter function used by the plugin
 
-Returns **[Function][80]** the filter function
+Returns **[Function][84]** the filter function
 
 ### setFilter
 
@@ -366,9 +372,9 @@ Set the filter function used by the plugin.
 
 #### Parameters
 
--   `filter` **[Function][80]** A function which accepts a Feature in the [Carmen GeoJSON][81] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+-   `filter` **[Function][84]** A function which accepts a Feature in the [Carmen GeoJSON][85] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### setOrigin
 
@@ -376,15 +382,15 @@ Set the geocoding endpoint used by the plugin.
 
 #### Parameters
 
--   `origin` **[Function][80]** A function which accepts an HTTPS URL to specify the endpoint to query results from.
+-   `origin` **[Function][84]** A function which accepts an HTTPS URL to specify the endpoint to query results from.
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### getOrigin
 
 Get the geocoding endpoint the plugin is currently set to
 
-Returns **[Function][80]** the endpoint URL
+Returns **[Function][84]** the endpoint URL
 
 ### setAccessToken
 
@@ -392,9 +398,9 @@ Set the accessToken option used for the geocoding request endpoint.
 
 #### Parameters
 
--   `accessToken` **[String][71]** value
+-   `accessToken` **[String][75]** value
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
 
 ### setAutocomplete
 
@@ -402,13 +408,13 @@ Set the autocomplete option used for geocoding requests
 
 #### Parameters
 
--   `value` **[Boolean][75]** The boolean value to set autocomplete to
+-   `value` **[Boolean][79]** The boolean value to set autocomplete to
 
 ### getAutocomplete
 
 Get the current autocomplete parameter value used for requests
 
-Returns **[Boolean][75]** The autocomplete parameter value
+Returns **[Boolean][79]** The autocomplete parameter value
 
 ### setFuzzyMatch
 
@@ -416,13 +422,13 @@ Set the fuzzyMatch option used for approximate matching in geocoding requests
 
 #### Parameters
 
--   `value` **[Boolean][75]** The boolean value to set fuzzyMatch to
+-   `value` **[Boolean][79]** The boolean value to set fuzzyMatch to
 
 ### getFuzzyMatch
 
 Get the current fuzzyMatch parameter value used for requests
 
-Returns **[Boolean][75]** The fuzzyMatch parameter value
+Returns **[Boolean][79]** The fuzzyMatch parameter value
 
 ### setRouting
 
@@ -430,13 +436,13 @@ Set the routing parameter used to ask for routable point metadata in geocoding r
 
 #### Parameters
 
--   `value` **[Boolean][75]** The boolean value to set routing to
+-   `value` **[Boolean][79]** The boolean value to set routing to
 
 ### getRouting
 
 Get the current routing parameter value used for requests
 
-Returns **[Boolean][75]** The routing parameter value
+Returns **[Boolean][79]** The routing parameter value
 
 ### setWorldview
 
@@ -444,13 +450,13 @@ Set the worldview parameter
 
 #### Parameters
 
--   `code` **[String][71]** The country code representing the worldview (e.g. "us" | "cn" | "jp", "in")
+-   `code` **[String][75]** The country code representing the worldview (e.g. "us" | "cn" | "jp", "in")
 
 ### getWorldview
 
 Get the current worldview parameter value used for requests
 
-Returns **[String][71]** The worldview parameter value
+Returns **[String][75]** The worldview parameter value
 
 ### on
 
@@ -458,14 +464,14 @@ Subscribe to events that happen within the plugin.
 
 #### Parameters
 
--   `type` **[String][71]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
+-   `type` **[String][75]** name of event. Available events and the data passed into their respective event objects are:-   **clear** `Emitted when the input is cleared`
     -   **loading** `{ query } Emitted when the geocoder is looking up a query`
     -   **results** `{ results } Fired when the geocoder returns a response`
     -   **result** `{ result } Fired when input is set`
     -   **error** `{ error } Error as string`
--   `fn` **[Function][80]** function that's called when the event is emitted.
+-   `fn` **[Function][84]** function that's called when the event is emitted.
 
-Returns **[MapboxGeocoder][83]** this;
+Returns **[MapboxGeocoder][87]** this;
 
 ### off
 
@@ -473,10 +479,29 @@ Remove an event
 
 #### Parameters
 
--   `type` **[String][71]** Event name.
--   `fn` **[Function][80]** Function that should unsubscribe to the event emitted.
+-   `type` **[String][75]** Event name.
+-   `fn` **[Function][84]** Function that should unsubscribe to the event emitted.
 
-Returns **[MapboxGeocoder][83]** this
+Returns **[MapboxGeocoder][87]** this
+
+## transformFeatureToGeolocationText
+
+This function transforms the feature from reverse geocoding to plain text with specified accuracy
+
+### Parameters
+
+-   `feature` **[object][74]** 
+-   `accuracy` **[string][75]** 
+
+## getAddressInfo
+
+This function transforms the feature from reverse geocoding to AddressInfo object
+
+### Parameters
+
+-   `feature` **[object][74]** 
+
+Returns **[object][74]** 
 
 [1]: #mapboxgeocoder
 
@@ -614,44 +639,52 @@ Returns **[MapboxGeocoder][83]** this
 
 [68]: #parameters-24
 
-[69]: https://docs.mapbox.com/api/search/#geocoding
+[69]: #transformfeaturetogeolocationtext
 
-[70]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[70]: #parameters-25
 
-[71]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[71]: #getaddressinfo
 
-[72]: https://github.com/mapbox/mapbox-gl-js
+[72]: #parameters-26
 
-[73]: https://docs.mapbox.com/mapbox-gl-js/api/#marker
+[73]: https://docs.mapbox.com/api/search/#geocoding
 
-[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[75]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[75]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[76]: https://docs.mapbox.com/mapbox-gl-js/api/#map#flyto
+[76]: https://github.com/mapbox/mapbox-gl-js
 
-[77]: https://docs.mapbox.com/mapbox-gl-js/api/#map#fitbounds
+[77]: https://docs.mapbox.com/mapbox-gl-js/api/#marker
 
-[78]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[78]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[79]: https://docs.mapbox.com/api/search/#data-types
+[79]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[80]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[80]: https://docs.mapbox.com/mapbox-gl-js/api/#map#flyto
 
-[81]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+[81]: https://docs.mapbox.com/mapbox-gl-js/api/#map#fitbounds
 
-[82]: https://docs.mapbox.com/api/search/#endpoints
+[82]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[83]: #mapboxgeocoder
+[83]: https://docs.mapbox.com/api/search/#data-types
 
-[84]: https://docs.mapbox.com/mapbox-gl-js/api/map/
+[84]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[85]: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#addcontrol
+[85]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
 
-[86]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
+[86]: https://docs.mapbox.com/api/search/#endpoints
 
-[87]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors
+[87]: #mapboxgeocoder
 
-[88]: https://developer.mozilla.org/docs/Web/HTML/Element
+[88]: https://docs.mapbox.com/mapbox-gl-js/api/map/
 
-[89]: https://developer.mozilla.org/docs/Web/API/Event
+[89]: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#addcontrol
+
+[90]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
+
+[91]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors
+
+[92]: https://developer.mozilla.org/docs/Web/HTML/Element
+
+[93]: https://developer.mozilla.org/docs/Web/API/Event

--- a/API.md
+++ b/API.md
@@ -117,6 +117,8 @@ A geocoder component using the [Mapbox Geocoding API][67]
     -   `options.fuzzyMatch` **[Boolean][73]** Specify whether the Geocoding API should attempt approximate, as well as exact, matching when performing searches, or whether it should opt out of this behavior and only attempt exact matching. (optional, default `true`)
     -   `options.routing` **[Boolean][73]** Specify whether to request additional metadata about the recommended navigation destination corresponding to the feature or not. Only applicable for address features. (optional, default `false`)
     -   `options.worldview` **[String][69]** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups. (optional, default `"us"`)
+    -   `options.enableGeolocation` **[Boolean][73]** If `true` enable user geolocation feature. (optional, default `false`)
+    -   `options.addressAccuracy` **(`"address"` \| `"street"` \| `"place"` \| `"country"`)** The accuracy for the geolocation feature with which we define the address line to fill. The browser API returns the user's position with accuracy, and sometimes we can get the neighbor's address. To prevent receiving an incorrect address, you can reduce the accuracy of the definition. (optional, default `"street"`)
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,13 @@
 
 - Adds `setAccessToken` method to update the accessToken after the Geocoder has been initialized [#449](https://github.com/mapbox/mapbox-gl-geocoder/pull/449)
 - Enables use of the value `'ip'` for `proximity` to bias around a user's location [#453](https://github.com/mapbox/mapbox-gl-geocoder/pull/453)
-- Adds `events` dependency to resolve a Node emulation issue for use in packagers such as Vite [#451](https://github.com/mapbox/mapbox-gl-geocoder/pull/451)
+- Added geolocate functionality [#444](https://github.com/mapbox/mapbox-gl-geocoder/pull/444)
 
 ### Dependency update
 
 - Bumps `nanoid` to v3.1.31 to resolve security vulnerability warning.
 - Adds `babelify` to build process to ensure mapbox-gl-geocoder remains ES5-compatible.
-
-## 4.8.0
-
-### Features / Improvements 🚀
-
-- Added geolocate functionality [#444](https://github.com/mapbox/mapbox-gl-geocoder/pull/444)
+- Adds `events` dependency to resolve a Node emulation issue for use in packagers such as Vite [#451](https://github.com/mapbox/mapbox-gl-geocoder/pull/451)
 
 ## 4.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master
 
+## 4.8.0
+
+### Features / Improvements 🚀
+
+- Added geolocate functionality [#444](https://github.com/mapbox/mapbox-gl-geocoder/pull/444)
+
 ## 4.7.4
 
 ### Features / Improvements 🚀

--- a/debug/index.js
+++ b/debug/index.js
@@ -74,6 +74,7 @@ var coordinatesGeocoder = function(query) {
 var geocoder = new MapboxGeocoder({
   accessToken: mapboxgl.accessToken,
   trackProximity: true,
+  enableGeolocation: true,
   localGeocoder: function(query) {
     return coordinatesGeocoder(query);
   },

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -11,30 +11,30 @@ Geolocation.prototype = {
       enableHighAccuracy: true
     };
 
-    return new Promise(function(res, rej) {
-      window.navigator.geolocation.getCurrentPosition(res, rej, positionOptions);
+    return new Promise(function(resolve, reject) {
+      window.navigator.geolocation.getCurrentPosition(resolve, reject, positionOptions);
     });
   },
 
   checkGeolocationSupport: function () {
-    return new Promise(function(res, rej) {
+    return new Promise(function(resolve, reject) {
       if (this.supportsGeolocation !== undefined) {
-        res(this.supportsGeolocation);
+        resolve(this.supportsGeolocation);
     
       } else if (window.navigator.permissions !== undefined) {
         // navigator.permissions has incomplete browser support
         // http://caniuse.com/#feat=permissions-api
         // Test for the case where a browser disables Geolocation because of an
         // insecure origin
-        window.navigator.permissions.query({name: 'geolocation'}).then(function (p) {
+        window.navigator.permissions.query({name: 'geolocation'}).then(function (permissions) {
           //TODO: PermissionStatus{state: 'denied', onchange: null}
-          this.supportsGeolocation = p.state !== 'denied';
-          res(this.supportsGeolocation);
-        }.bind(this)).catch(rej);
+          this.supportsGeolocation = permissions.state !== 'denied';
+          resolve(this.supportsGeolocation);
+        }.bind(this)).catch(reject);
     
       } else {
         this.supportsGeolocation = !!window.navigator.geolocation;
-        res(this.supportsGeolocation);
+        resolve(this.supportsGeolocation);
       }
     }.bind(this)).then(function (supportsGeolocation) {
       this.supportsGeolocation  = supportsGeolocation;

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -1,0 +1,46 @@
+function Geolocation() {}
+
+Geolocation.prototype = {
+
+  isSupport: function() {
+    return this.supportsGeolocation;
+  },
+
+  getCurrentPosition: function() {
+    const positionOptions = {
+      enableHighAccuracy: true
+    };
+
+    return new Promise(function(res, rej) {
+      window.navigator.geolocation.getCurrentPosition(res, rej, positionOptions);
+    });
+  },
+
+  checkGeolocationSupport: function () {
+    return new Promise(function(res, rej) {
+      if (this.supportsGeolocation !== undefined) {
+        res(this.supportsGeolocation);
+    
+      } else if (window.navigator.permissions !== undefined) {
+        // navigator.permissions has incomplete browser support
+        // http://caniuse.com/#feat=permissions-api
+        // Test for the case where a browser disables Geolocation because of an
+        // insecure origin
+        window.navigator.permissions.query({name: 'geolocation'}).then(function (p) {
+          //TODO: PermissionStatus{state: 'denied', onchange: null}
+          this.supportsGeolocation = p.state !== 'denied';
+          res(this.supportsGeolocation);
+        }.bind(this)).catch(rej);
+    
+      } else {
+        this.supportsGeolocation = !!window.navigator.geolocation;
+        res(this.supportsGeolocation);
+      }
+    }.bind(this)).then(function (supportsGeolocation) {
+      this.supportsGeolocation  = supportsGeolocation;
+      return supportsGeolocation;
+    }.bind(this));
+  },
+}
+
+module.exports = Geolocation;

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -3,7 +3,7 @@ function Geolocation() {}
 Geolocation.prototype = {
 
   isSupport: function() {
-    return this.supportsGeolocation;
+    return Boolean(window.navigator.geolocation);
   },
 
   getCurrentPosition: function() {
@@ -14,32 +14,6 @@ Geolocation.prototype = {
     return new Promise(function(resolve, reject) {
       window.navigator.geolocation.getCurrentPosition(resolve, reject, positionOptions);
     });
-  },
-
-  checkGeolocationSupport: function () {
-    return new Promise(function(resolve, reject) {
-      if (this.supportsGeolocation !== undefined) {
-        resolve(this.supportsGeolocation);
-    
-      } else if (window.navigator.permissions !== undefined) {
-        // navigator.permissions has incomplete browser support
-        // http://caniuse.com/#feat=permissions-api
-        // Test for the case where a browser disables Geolocation because of an
-        // insecure origin
-        window.navigator.permissions.query({name: 'geolocation'}).then(function (permissions) {
-          //TODO: PermissionStatus{state: 'denied', onchange: null}
-          this.supportsGeolocation = permissions.state !== 'denied';
-          resolve(this.supportsGeolocation);
-        }.bind(this)).catch(reject);
-    
-      } else {
-        this.supportsGeolocation = !!window.navigator.geolocation;
-        resolve(this.supportsGeolocation);
-      }
-    }.bind(this)).then(function (supportsGeolocation) {
-      this.supportsGeolocation  = supportsGeolocation;
-      return supportsGeolocation;
-    }.bind(this));
   },
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ const GEOCODE_REQUEST_TYPE = {
  * @param {Boolean} [options.routing=false] Specify whether to request additional metadata about the recommended navigation destination corresponding to the feature or not. Only applicable for address features.
  * @param {String} [options.worldview="us"] Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
  * @param {Boolean} [options.enableGeolocation=false] If `true` enable user geolocation feature.
- * @param {('address'|'street'|'place'|'country')} [options.addressAccuracy="street"] The accuracy with which we define the address line to fill. The browser API returns the user's position with accuracy, and sometimes we can get the neighbor's address. We suggest using "street" accuracy.
+ * @param {('address'|'street'|'place'|'country')} [options.addressAccuracy="street"] The accuracy for the geolocation feature with which we define the address line to fill. The browser API returns the user's position with accuracy, and sometimes we can get the neighbor's address. To prevent receiving an incorrect address, you can reduce the accuracy of the definition.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);

--- a/lib/index.js
+++ b/lib/index.js
@@ -251,18 +251,11 @@ MapboxGeocoder.prototype = {
     el.appendChild(this._inputEl);
     el.appendChild(actions);
 
-    if (this.options.enableGeolocation) {
-      this.geolocation.checkGeolocationSupport().then(function (supportsGeolocation) {
-        if (supportsGeolocation) {
-          this._geolocateEl = this.createIcon('geolocate', '<path d="M12.999 3.677L2.042 8.269c-.962.403-.747 1.823.29 1.912l5.032.431.431 5.033c.089 1.037 1.509 1.252 1.912.29l4.592-10.957c.345-.822-.477-1.644-1.299-1.299z" fill="#4264fb"/>');
-          actions.appendChild(this._geolocateEl);
-          this._geolocateEl.addEventListener('click', this._geolocateUser);
-  
-          if (this.fresh) {
-            this._showGeolocateButton();
-          }
-        }
-      }.bind(this));
+    if (this.options.enableGeolocation && this.geolocation.isSupport()) {
+      this._geolocateEl = this.createIcon('geolocate', '<path d="M12.999 3.677L2.042 8.269c-.962.403-.747 1.823.29 1.912l5.032.431.431 5.033c.089 1.037 1.509 1.252 1.912.29l4.592-10.957c.345-.822-.477-1.644-1.299-1.299z" fill="#4264fb"/>');
+      actions.appendChild(this._geolocateEl);
+      this._geolocateEl.addEventListener('click', this._geolocateUser);
+      this._showGeolocateButton();
     }
 
     this._typeahead = new Typeahead(this._inputEl, [], {
@@ -341,10 +334,15 @@ MapboxGeocoder.prototype = {
           }
         }.bind(this));
       }
-    }.bind(this)).catch(function() {
+    }.bind(this)).catch(function(error) {
+      if (error.code === 1) {
+        this._renderUserDeniedGeolocationError();
+      } else {
+        this._renderLocationError();
+      }
+
       this._hideLoadingIcon();
       this._showGeolocateButton();
-      this._renderLocationError();
     }.bind(this));
   },
 
@@ -853,6 +851,11 @@ MapboxGeocoder.prototype = {
 
   _renderNoResults: function(){
     var errorMessage = "<div class='mapbox-gl-geocoder--error mapbox-gl-geocoder--no-results'>No results found</div>";
+    this._renderMessage(errorMessage);
+  },
+
+  _renderUserDeniedGeolocationError: function() {
+    var errorMessage = "<div class='mapbox-gl-geocoder--error'>You denied Geolocation</div>"
     this._renderMessage(errorMessage);
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ var mbxGeocoder = require('@mapbox/mapbox-sdk/services/geocoding');
 var MapboxEventManager = require('./events');
 var localization = require('./localization');
 var subtag = require('subtag');
+var Geolocation = require('./geolocation');
+var utils = require('./utils');
 
 
 const GEOCODE_REQUEST_TYPE = {
@@ -63,6 +65,8 @@ const GEOCODE_REQUEST_TYPE = {
  * @param {Boolean} [options.fuzzyMatch=true] Specify whether the Geocoding API should attempt approximate, as well as exact, matching when performing searches, or whether it should opt out of this behavior and only attempt exact matching.
  * @param {Boolean} [options.routing=false] Specify whether to request additional metadata about the recommended navigation destination corresponding to the feature or not. Only applicable for address features.
  * @param {String} [options.worldview="us"] Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+ * @param {Boolean} [options.enableGeolocation=false] If `true` enable user geolocation feature.
+ * @param {('address'|'street'|'place'|'country')} [options.addressAccuracy="street"] The accuracy with which we define the address line to fill. The browser API returns the user's position with accuracy, and sometimes we can get the neighbor's address. We suggest using "street" accuracy.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -76,6 +80,7 @@ function MapboxGeocoder(options) {
   this.inputString = '';
   this.fresh = true;
   this.lastSelected = null;
+  this.geolocation = new Geolocation();
 }
 
 MapboxGeocoder.prototype = {
@@ -93,6 +98,8 @@ MapboxGeocoder.prototype = {
     collapsed: false,
     clearAndBlurOnEsc: false,
     clearOnBlur: false,
+    enableGeolocation: false,
+    addressAccuracy: 'street',
     getItemValue: function(item) {
       return item.place_name
     },
@@ -191,6 +198,7 @@ MapboxGeocoder.prototype = {
     this._unCollapse = this._unCollapse.bind(this);
     this._clear = this._clear.bind(this);
     this._clearOnBlur = this._clearOnBlur.bind(this);
+    this._geolocateUser = this._geolocateUser.bind(this);
 
     var el = (this.container = document.createElement('div'));
     el.className = 'mapboxgl-ctrl-geocoder mapboxgl-ctrl';
@@ -243,6 +251,20 @@ MapboxGeocoder.prototype = {
     el.appendChild(this._inputEl);
     el.appendChild(actions);
 
+    if (this.options.enableGeolocation) {
+      this.geolocation.checkGeolocationSupport().then(function (supportsGeolocation) {
+        if (supportsGeolocation) {
+          this._geolocateEl = this.createIcon('geolocate', '<path d="M12.999 3.677L2.042 8.269c-.962.403-.747 1.823.29 1.912l5.032.431.431 5.033c.089 1.037 1.509 1.252 1.912.29l4.592-10.957c.345-.822-.477-1.644-1.299-1.299z" fill="#4264fb"/>');
+          actions.appendChild(this._geolocateEl);
+          this._geolocateEl.addEventListener('click', this._geolocateUser);
+  
+          if (this.fresh) {
+            this._showGeolocateButton();
+          }
+        }
+      }.bind(this));
+    }
+
     this._typeahead = new Typeahead(this._inputEl, [], {
       filter: false,
       minLength: this.options.minLength,
@@ -267,6 +289,63 @@ MapboxGeocoder.prototype = {
       }
     }
     return el;
+  },
+
+  _geolocateUser: function () {
+    this._hideGeolocateButton();
+    this._showLoadingIcon();
+
+    this.geolocation.getCurrentPosition().then(function(geolocationPosition) {
+      this._hideLoadingIcon();
+
+      const geojson = {
+        geometry: {
+          type: 'Point',
+          coordinates: [geolocationPosition.coords.longitude, geolocationPosition.coords.latitude]
+        }
+      };
+
+      this._handleMarker(geojson);
+      this._fly(geojson);
+
+      this._typeahead.clear();
+      this._typeahead.selected = true;
+      this.lastSelected = JSON.stringify(geojson);
+      this._showClearButton();
+      this.fresh = false;
+
+      const config = {
+        limit: 1,
+        language: [this.options.language],
+        query: geojson.geometry.coordinates,
+        types: ["address"]
+      };
+
+      if (this.options.localGeocoderOnly) {
+        const text = geojson.geometry.coordinates[0] + ',' + geojson.geometry.coordinates[1]
+        this._setInputValue(text);
+
+        this._eventEmitter.emit('result', { result: geojson });
+      } else {
+        this.geocoderService.reverseGeocode(config).send().then(function (resp) {
+          const feature = resp.body.features[0];
+  
+          if (feature) {
+            const locationText = utils.transformFeatureToGeolocationText(feature, this.options.addressAccuracy);
+            this._setInputValue(locationText);
+  
+            feature.user_coordinates = geojson.geometry.coordinates;
+            this._eventEmitter.emit('result', { result: feature });
+          } else {
+            this._eventEmitter.emit('result', { result: { user_coordinates: geojson.geometry.coordinates } });
+          }
+        }.bind(this));
+      }
+    }.bind(this)).catch(function() {
+      this._hideLoadingIcon();
+      this._showGeolocateButton();
+      this._renderLocationError();
+    }.bind(this));
   },
 
   createIcon: function(name, path) {
@@ -303,6 +382,16 @@ MapboxGeocoder.prototype = {
     return this;
   },
 
+  _setInputValue: function (value) {
+    this._inputEl.value = value;
+  
+    setTimeout(function () {
+      this._inputEl.focus();
+      this._inputEl.scrollLeft = 0;
+      this._inputEl.setSelectionRange(0, 0);
+    }.bind(this), 1);
+  },
+
   _onPaste: function(e){
     var value = (e.clipboardData || window.clipboardData).getData('text');
     if (value.length >= this.options.minLength) {
@@ -329,8 +418,11 @@ MapboxGeocoder.prototype = {
       this.fresh = true;
       // the user has removed all the text
       if (e.keyCode !== TAB_KEY_CODE) this.clear(e);
-      return (this._clearEl.style.display = 'none');
+      this._showGeolocateButton();
+      return this._hideClearButton();
     }
+
+    this._hideGeolocateButton();
 
     // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
     if ((e.metaKey || [TAB_KEY_CODE, ESC_KEY_CODE, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1))
@@ -342,11 +434,39 @@ MapboxGeocoder.prototype = {
   },
 
   _showButton: function() {
-    if (this._typeahead.selected) this._clearEl.style.display = 'block';
+    if (this._typeahead.selected) this._showClearButton();
   },
 
   _hideButton: function() {
-    if (this._typeahead.selected) this._clearEl.style.display = 'none';
+    if (this._typeahead.selected) this._hideClearButton();
+  },
+
+  _showClearButton: function() {
+    this._clearEl.style.display = 'block';
+  },
+
+  _hideClearButton: function() {
+    this._clearEl.style.display = 'none'
+  },
+
+  _showGeolocateButton: function() {
+    if (this._geolocateEl && this.geolocation.isSupport()) {
+      this._geolocateEl.style.display = 'block';
+    }
+  },
+
+  _hideGeolocateButton: function() {
+    if (this._geolocateEl) {
+      this._geolocateEl.style.display = 'none';
+    }
+  },
+
+  _showLoadingIcon: function() {
+    this._loadingEl.style.display = 'block';
+  },
+  
+  _hideLoadingIcon: function() {
+    this._loadingEl.style.display = 'none';
   },
 
   _onBlur: function(e) {
@@ -360,42 +480,9 @@ MapboxGeocoder.prototype = {
   _onChange: function() {
     var selected = this._typeahead.selected;
     if (selected  && JSON.stringify(selected) !== this.lastSelected) {
-      this._clearEl.style.display = 'none';
+      this._hideClearButton();
       if (this.options.flyTo) {
-        var flyOptions;
-        if (selected.properties && exceptions[selected.properties.short_code]) {
-          // Certain geocoder search results return (and therefore zoom to fit)
-          // an unexpectedly large bounding box: for example, both Russia and the
-          // USA span both sides of -180/180, or France includes the island of
-          // Reunion in the Indian Ocean. An incomplete list of these exceptions
-          // at ./exceptions.json provides "reasonable" bounding boxes as a
-          // short-term solution; this may be amended as necessary.
-          flyOptions = extend({}, this.options.flyTo);
-          if (this._map){
-            this._map.fitBounds(exceptions[selected.properties.short_code].bbox, flyOptions);
-          }
-        } else if (selected.bbox) {
-          var bbox = selected.bbox;
-          flyOptions = extend({}, this.options.flyTo);
-          if (this._map){
-            this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
-          }
-        } else {
-          var defaultFlyOptions = {
-            zoom: this.options.zoom
-          }
-          flyOptions = extend({}, defaultFlyOptions, this.options.flyTo);
-          //  ensure that center is not overriden by custom options
-          if (selected.center) {
-            flyOptions.center = selected.center;
-          } else if (selected.geometry && selected.geometry.type && selected.geometry.type === 'Point' && selected.geometry.coordinates) {
-            flyOptions.center = selected.geometry.coordinates;
-          }
-
-          if (this._map){
-            this._map.flyTo(flyOptions);
-          }
-        }
+        this._fly(selected);
       }
       if (this.options.marker && this._mapboxgl){
         this._handleMarker(selected);
@@ -409,6 +496,43 @@ MapboxGeocoder.prototype = {
       this.lastSelected = JSON.stringify(selected);
       this._eventEmitter.emit('result', { result: selected });
       this.eventManager.select(selected, this);
+    }
+  },
+
+  _fly: function(selected) {
+    var flyOptions;
+    if (selected.properties && exceptions[selected.properties.short_code]) {
+      // Certain geocoder search results return (and therefore zoom to fit)
+      // an unexpectedly large bounding box: for example, both Russia and the
+      // USA span both sides of -180/180, or France includes the island of
+      // Reunion in the Indian Ocean. An incomplete list of these exceptions
+      // at ./exceptions.json provides "reasonable" bounding boxes as a
+      // short-term solution; this may be amended as necessary.
+      flyOptions = extend({}, this.options.flyTo);
+      if (this._map){
+        this._map.fitBounds(exceptions[selected.properties.short_code].bbox, flyOptions);
+      }
+    } else if (selected.bbox) {
+      var bbox = selected.bbox;
+      flyOptions = extend({}, this.options.flyTo);
+      if (this._map){
+        this._map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], flyOptions);
+      }
+    } else {
+      var defaultFlyOptions = {
+        zoom: this.options.zoom
+      }
+      flyOptions = extend({}, defaultFlyOptions, this.options.flyTo);
+      //  ensure that center is not overriden by custom options
+      if (selected.center) {
+        flyOptions.center = selected.center;
+      } else if (selected.geometry && selected.geometry.type && selected.geometry.type === 'Point' && selected.geometry.coordinates) {
+        flyOptions.center = selected.geometry.coordinates;
+      }
+
+      if (this._map){
+        this._map.flyTo(flyOptions);
+      }
     }
   },
 
@@ -505,7 +629,7 @@ MapboxGeocoder.prototype = {
 
   _geocode: function(searchInput) {
     this.inputString = searchInput;
-    this._loadingEl.style.display = 'block';
+    this._showLoadingIcon();
     this._eventEmitter.emit('loading', { query: searchInput });
 
     const requestType = this._requestType(this.options, searchInput);
@@ -533,7 +657,7 @@ MapboxGeocoder.prototype = {
     }.bind(this))
       .then(
         function(response) {
-          this._loadingEl.style.display = 'none';
+          this._hideLoadingIcon();
 
           var res = {};
 
@@ -586,11 +710,12 @@ MapboxGeocoder.prototype = {
           }
 
           if (res.features.length) {
-            this._clearEl.style.display = 'block';
+            this._showClearButton();
+            this._hideGeolocateButton();
             this._eventEmitter.emit('results', res);
             this._typeahead.update(res.features);
           } else {
-            this._clearEl.style.display = 'none';
+            this._hideClearButton();
             this._typeahead.selected = null;
             this._renderNoResults();
             this._eventEmitter.emit('results', res);
@@ -599,14 +724,15 @@ MapboxGeocoder.prototype = {
         }.bind(this)
       ).catch(
         function(err) {
-          this._loadingEl.style.display = 'none';
+          this._hideLoadingIcon();
 
           // in the event of an error in the Mapbox Geocoding API still display results from the localGeocoder
           if ((localGeocoderRes.length && this.options.localGeocoder) || (externalGeocoderRes.length && this.options.externalGeocoder) ) {
-            this._clearEl.style.display = 'block';
+            this._showClearButton();
+            this._hideGeolocateButton();
             this._typeahead.update(localGeocoderRes);
           } else {
-            this._clearEl.style.display = 'none';
+            this._hideClearButton();
             this._typeahead.selected = null;
             this._renderError();
           }
@@ -631,7 +757,8 @@ MapboxGeocoder.prototype = {
     this._typeahead.selected = null;
     this._typeahead.clear();
     this._onChange();
-    this._clearEl.style.display = 'none';
+    this._hideClearButton();
+    this._showGeolocateButton();
     this._removeMarker();
     this.lastSelected = null;
     this._eventEmitter.emit('clear');
@@ -716,6 +843,11 @@ MapboxGeocoder.prototype = {
 
   _renderError: function(){
     var errorMessage = "<div class='mapbox-gl-geocoder--error'>There was an error reaching the server</div>"
+    this._renderMessage(errorMessage);
+  },
+
+  _renderLocationError: function(){
+    var errorMessage = "<div class='mapbox-gl-geocoder--error'>A location error has occurred</div>"
     this._renderMessage(errorMessage);
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -843,7 +843,7 @@ MapboxGeocoder.prototype = {
   },
 
   _renderUserDeniedGeolocationError: function() {
-    var errorMessage = "<div class='mapbox-gl-geocoder--error'>You denied Geolocation</div>"
+    var errorMessage = "<div class='mapbox-gl-geocoder--error'>Geolocation permission denied</div>"
     this._renderMessage(errorMessage);
   },
 

--- a/lib/mapbox-gl-geocoder.css
+++ b/lib/mapbox-gl-geocoder.css
@@ -152,6 +152,13 @@
   fill: #909090;
 }
 
+.mapboxgl-ctrl-geocoder--icon-geolocate {
+  width: 22px;
+  height: 22px;
+  margin-top: 6px;
+  margin-right: 3px;
+}
+
 .mapboxgl-ctrl-geocoder--icon-loading {
   width: 26px;
   height: 26px;
@@ -211,6 +218,13 @@
     width: 16px;
     height: 16px;
     margin-top: 3px;
+    margin-right: 0;
+  }
+
+  .mapboxgl-ctrl-geocoder--icon-geolocate {
+    width: 18px;
+    height: 18px;
+    margin-top: 2px;
     margin-right: 0;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,56 @@
+function transformFeatureToGeolocationText(feature, accuracy) {
+  const addrInfo = getAddressInfo(feature);
+
+  const addressAccuracy =  ['address', 'street', 'place', 'country'];
+  var currentAccuracy;
+
+  if (typeof accuracy === 'function') {
+    return accuracy(addrInfo)
+  }
+
+  const accuracyIndex = addressAccuracy.indexOf(accuracy);
+
+  if (accuracyIndex === -1) {
+    currentAccuracy = addressAccuracy;
+  } else {
+    currentAccuracy = addressAccuracy.slice(accuracyIndex);
+  }
+
+  return currentAccuracy.reduce(function(acc, name) {
+    if (!addrInfo[name]) {
+      return acc;
+    }
+
+    if (acc !== '') {
+      acc = acc + ', ';
+    }
+
+    return acc + addrInfo[name];
+  }, '');
+}
+
+function getAddressInfo(feature) {
+  const houseNumber = feature.address || '';
+  const street = feature.text || '';
+  const placeName = feature.place_name || '';
+  const address = placeName.split(',')[0];
+
+  const addrInfo = {
+    address: address,
+    houseNumber: houseNumber,
+    street: street,
+    placeName: placeName,
+  }
+
+  feature.context.forEach(function (context) {
+    const layer = context.id.split('.')[0];
+    addrInfo[layer] = context.text;
+  });
+
+  return addrInfo;
+}
+
+module.exports = {
+  transformFeatureToGeolocationText: transformFeatureToGeolocationText,
+  getAddressInfo: getAddressInfo,
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,9 @@
+/**
+ * This function transforms the feature from reverse geocoding to plain text with specified accuracy
+ * @param {object} feature 
+ * @param {string} accuracy 
+ * @returns 
+ */
 function transformFeatureToGeolocationText(feature, accuracy) {
   const addrInfo = getAddressInfo(feature);
 
@@ -28,7 +34,11 @@ function transformFeatureToGeolocationText(feature, accuracy) {
     return acc + addrInfo[name];
   }, '');
 }
-
+/**
+ * This function transforms the feature from reverse geocoding to AddressInfo object
+ * @param {object} feature 
+ * @returns {object}
+ */
 function getAddressInfo(feature) {
   const houseNumber = feature.address || '';
   const street = feature.text || '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "4.8.0",
+  "version": "4.7.4",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -483,6 +483,59 @@ test('Geocoder#addTo(String) -- no map', function(tt) {
 
     geocoder.query('-79,43');
   });
+
+  tt.test('should add geolocate icon when browser supports geolocation', (t)=>{
+    t.plan(1);
+
+    const opts = { enableGeolocation: true };
+    opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
+    const container = document.createElement('div');
+    container.className = "notAMap"
+    document.body.appendChild(container)
+    const geocoder = new MapboxGeocoder(opts);
+
+    const geolocation = geocoder.geolocation;
+
+    sinon.stub(geolocation, 'checkGeolocationSupport').resolves(true);
+
+    geocoder.addTo(".notAMap")
+
+    setTimeout(() => {
+      const geolocateEl = container.querySelector('.mapboxgl-ctrl-geocoder--icon-geolocate');
+
+      t.ok(geolocateEl !== null, 'geolocate icon was shown');
+
+      t.end(); 
+    }, 100);
+  });
+
+  tt.test('should hide geolocate icon when browser doesn\'t support geolocation', (t)=>{
+    t.plan(1);
+
+    const opts = { enableGeolocation: true };
+    opts.accessToken = mapboxgl.accessToken;
+    opts.enableEventLogging = false;
+    const container = document.createElement('div');
+    container.className = "notAMap"
+    document.body.appendChild(container)
+    const geocoder = new MapboxGeocoder(opts);
+
+    const geolocation = geocoder.geolocation;
+
+    sinon.stub(geolocation, 'checkGeolocationSupport').resolves(false);
+
+    geocoder.addTo(".notAMap")
+
+    setTimeout(() => {
+      const geolocateEl = container.querySelector('.mapboxgl-ctrl-geocoder--icon-geolocate');
+
+      t.ok(geolocateEl === null, 'geolocate icon was shown');
+
+      t.end(); 
+    }, 100);
+  });
+  
 });
 
 

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -497,7 +497,7 @@ test('Geocoder#addTo(String) -- no map', function(tt) {
 
     const geolocation = geocoder.geolocation;
 
-    sinon.stub(geolocation, 'checkGeolocationSupport').resolves(true);
+    sinon.stub(geolocation, 'isSupport').returns(true);
 
     geocoder.addTo(".notAMap")
 
@@ -523,7 +523,7 @@ test('Geocoder#addTo(String) -- no map', function(tt) {
 
     const geolocation = geocoder.geolocation;
 
-    sinon.stub(geolocation, 'checkGeolocationSupport').resolves(false);
+    sinon.stub(geolocation, 'isSupport').returns(false);
 
     geocoder.addTo(".notAMap")
 

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -505,7 +505,7 @@ test('Geocoder#addTo(String) -- no map', function(tt) {
       const geolocateEl = container.querySelector('.mapboxgl-ctrl-geocoder--icon-geolocate');
 
       t.ok(geolocateEl !== null, 'geolocate icon was shown');
-
+      container.remove();
       t.end(); 
     }, 100);
   });
@@ -531,7 +531,7 @@ test('Geocoder#addTo(String) -- no map', function(tt) {
       const geolocateEl = container.querySelector('.mapboxgl-ctrl-geocoder--icon-geolocate');
 
       t.ok(geolocateEl === null, 'geolocate icon was shown');
-
+      container.remove();
       t.end(); 
     }, 100);
   });


### PR DESCRIPTION
Add functionality to find user location through browser api.
<img width="320" alt="Screenshot 2021-12-07 at 13 01 29" src="https://user-images.githubusercontent.com/6375386/145008273-f5f8cfb6-5161-4964-8ad6-90f66546066b.png">


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
