### PR TITLE
fix unsafe HTML construction with createIcon

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -276,16 +276,7 @@ MapboxGeocoder.prototype = {
     icon.setAttribute('xml:space','preserve');
     icon.setAttribute('width', 18);
     icon.setAttribute('height', 18);
-    // IE does not have innerHTML for SVG nodes
-    if (!('innerHTML' in icon)) {
-      var SVGNodeContainer = document.createElement('div');
-      SVGNodeContainer.innerHTML = '<svg>' + path.valueOf().toString() + '</svg>';
-      var SVGNode = SVGNodeContainer.firstChild,
-        SVGPath = SVGNode.firstChild;
-      icon.appendChild(SVGPath);
-    } else {
-      icon.innerHTML = path;
-    }
+    icon.innerHTML = path;
     return icon;
   },
 
@@ -482,7 +473,7 @@ MapboxGeocoder.prototype = {
       config = extend(config, { query: coords, limit: 1 });
 
       // Remove config options not supported by the reverseGeocoder
-      
+
       ['proximity', 'autocomplete', 'fuzzyMatch', 'bbox'].forEach(function(key) {
         if (key in config) {
           delete config[key]
@@ -562,7 +553,7 @@ MapboxGeocoder.prototype = {
 
           if (this.options.externalGeocoder) {
 
-            externalGeocoderRes = this.options.externalGeocoder(searchInput, res.features) || [];
+            externalGeocoderRes = this.options.externalGeocoder(searchInput, res.features) || Promise.resolve([]);
             // supplement Mapbox Geocoding API results with features returned by a promise
             return externalGeocoderRes.then(function(features) {
               res.features = res.features ? features.concat(res.features) : features;
@@ -1020,7 +1011,7 @@ MapboxGeocoder.prototype = {
   /**
    * Set the autocomplete option used for geocoding requests
    * @param {Boolean} value The boolean value to set autocomplete to
-   * @returns 
+   * @returns
    */
   setAutocomplete: function(value){
     this.options.autocomplete = value;
@@ -1038,7 +1029,7 @@ MapboxGeocoder.prototype = {
   /**
    * Set the fuzzyMatch option used for approximate matching in geocoding requests
    * @param {Boolean} value The boolean value to set fuzzyMatch to
-   * @returns 
+   * @returns
    */
   setFuzzyMatch: function(value){
     this.options.fuzzyMatch = value;
@@ -1056,7 +1047,7 @@ MapboxGeocoder.prototype = {
   /**
    * Set the routing parameter used to ask for routable point metadata in geocoding requests
    * @param {Boolean} value The boolean value to set routing to
-   * @returns 
+   * @returns
    */
   setRouting: function(value){
     this.options.routing = value;
@@ -1074,7 +1065,7 @@ MapboxGeocoder.prototype = {
   /**
    * Set the worldview parameter
    * @param {String} code The country code representing the worldview (e.g. "us" | "cn" | "jp", "in")
-   * @returns 
+   * @returns
    */
   setWorldview: function(code){
     this.options.worldview = code;


### PR DESCRIPTION
This PR removes IE support for icon creation and removes `createIcon` from the `MapboxGeocoder` prototype.