### PR TITLE
Enable proximity=ip and disabling of trackProximity

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,11 +28,8 @@ const GEOCODE_REQUEST_TYPE = {
  * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to when a `bbox` isn't found in the response. If a `bbox` is found the map will fit to the `bbox`.
  * @param {Boolean|Object} [options.flyTo=true] If `false`, animating the map to a selected result is disabled. If `true`, animating the map will use the default animation parameters. If an object, it will be passed as `options` to the map [`flyTo`](https://docs.mapbox.com/mapbox-gl-js/api/#map#flyto) or [`fitBounds`](https://docs.mapbox.com/mapbox-gl-js/api/#map#fitbounds) method providing control over the animation of the transition.
  * @param {String} [options.placeholder=Search] Override the default placeholder attribute value.
- * @param {Object} [options.proximity] a proximity argument: this is
- * a geographical point given as an object with `latitude` and `longitude`
- * properties. Search results closer to this point will be given
- * higher priority.
- * @param {Boolean} [options.trackProximity=true] If `true`, the geocoder proximity will automatically update based on the map view.
+ * @param {Object|'ip'} [options.proximity] a geographical point given as an object with `latitude` and `longitude` properties, or the string 'ip' to use a user's IP address location. Search results closer to this point will be given higher priority.
+ * @param {Boolean} [options.trackProximity=true] If `true`, the geocoder proximity will dynamically update based on the current map view or user's IP location, depending on zoom level.
  * @param {Boolean} [options.collapsed=false] If `true`, the geocoder control will collapse until hovered or in focus.
  * @param {Boolean} [options.clearAndBlurOnEsc=false] If `true`, the geocoder control will clear it's contents and blur when user presses the escape key.
  * @param {Boolean} [options.clearOnBlur=false] If `true`, the geocoder control will clear its value when the input blurs.
@@ -675,14 +672,14 @@ MapboxGeocoder.prototype = {
   _updateProximity: function() {
     // proximity is designed for local scale, if the user is looking at the whole world,
     // it doesn't make sense to factor in the arbitrary centre of the map
-    if (!this._map){
+    if (!this._map || !this.options.trackProximity){
       return;
     }
     if (this._map.getZoom() > 9) {
       var center = this._map.getCenter().wrap();
-      this.setProximity({ longitude: center.lng, latitude: center.lat });
+      this.setProximity({ longitude: center.lng, latitude: center.lat }, false);
     } else {
-      this.setProximity(null);
+      this.setProximity(null, false);
     }
   },
 
@@ -761,11 +758,15 @@ MapboxGeocoder.prototype = {
 
   /**
    * Set proximity
-   * @param {Object} proximity The new `options.proximity` value. This is a geographical point given as an object with `latitude` and `longitude` properties.
+   * @param {Object|'ip'} proximity The new `options.proximity` value. This is a geographical point given as an object with `latitude` and `longitude` properties or the string 'ip'.
+   * @param {Boolean} disableTrackProximity If true, sets `trackProximity` to false. True by default to prevent `trackProximity` from unintentionally overriding an explicitly set proximity value.
    * @returns {MapboxGeocoder} this
    */
-  setProximity: function(proximity) {
+  setProximity: function(proximity, disableTrackProximity = true) {
     this.options.proximity = proximity;
+    if (disableTrackProximity) {
+      this.options.trackProximity = false;
+    }
     return this;
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4028,9 +4028,9 @@
       "dev": true
     },
     "@mapbox/mapbox-sdk": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.2.tgz",
-      "integrity": "sha512-VP2+Gyada3G8IJPbiD+9KZMEIxqITyPjVL66FBav2qjFhlHf5LrRCoZ4IbI6Os8DZadSEyxDGVU/doLaohkJRw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.3.tgz",
+      "integrity": "sha512-IED4YiXRNJatYUYg423Vjb41o7D7aG8hXOlu+UITNYzci0b2p/2zpYw6UtFZ/vAXopWRBzTce5s9e+gGuUmKXg==",
       "requires": {
         "@mapbox/fusspot": "^0.4.0",
         "@mapbox/parse-mapbox-token": "^0.2.0",
@@ -4185,9 +4185,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/node": {
-      "version": "16.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.13.tgz",
-      "integrity": "sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA=="
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9248,9 +9248,9 @@
       "dev": true
     },
     "keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.1.1.tgz",
+      "integrity": "sha512-tGv1yP6snQVDSM4X6yxrv2zzq/EvpW+oYiUz6aueW1u9CtS8RzUQYxxmFwgZlO2jSgCxQbchhxaqXXp2hnKGpQ==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -9314,9 +9314,9 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "lint-staged": {
       "version": "8.2.1",
@@ -9965,9 +9965,9 @@
       }
     },
     "map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "map-visit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mapbox-gl": ">= 0.47.0 < 3.0.0"
   },
   "dependencies": {
-    "@mapbox/mapbox-sdk": "^0.13.2",
+    "@mapbox/mapbox-sdk": "^0.13.3",
     "lodash.debounce": "^4.0.6",
     "nanoid": "^3.1.31",
     "subtag": "^0.5.0",


### PR DESCRIPTION
- Adds documentation for usage of 'ip' as a value for `proximity` in line with the latest Geocoding API
- Bump to latest version of `mapbox-sdk-js`
- Disable `trackProximity` after proximity has been explicitly set via the `setProximity` method

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
