### PR TITLE
Hide attribution on error or no results

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -279,9 +279,9 @@ MapboxGeocoder.prototype = {
 
     // Add support for footer.
     var parentDraw = typeahead.list.draw;
+    var footerNode = this._footerNode = getFooterNode();
     typeahead.list.draw = function() {
       parentDraw.call(this);
-      var footerNode = getFooterNode();
 
       footerNode.addEventListener('mousedown', function() {
         this.selectingListItem = true;
@@ -370,6 +370,7 @@ MapboxGeocoder.prototype = {
 
       this._hideLoadingIcon();
       this._showGeolocateButton();
+      this._hideAttribution();
     }.bind(this));
   },
 
@@ -483,6 +484,14 @@ MapboxGeocoder.prototype = {
   
   _hideLoadingIcon: function() {
     this._loadingEl.style.display = 'none';
+  },
+
+  _showAttribution: function() {
+    this._footerNode.style.display = 'block'
+  },
+  
+  _hideAttribution: function() {
+    this._footerNode.style.display = 'none'
   },
 
   _onBlur: function(e) {
@@ -730,10 +739,12 @@ MapboxGeocoder.prototype = {
           if (res.features.length) {
             this._showClearButton();
             this._hideGeolocateButton();
+            this._showAttribution();
             this._eventEmitter.emit('results', res);
             this._typeahead.update(res.features);
           } else {
             this._hideClearButton();
+            this._hideAttribution();
             this._typeahead.selected = null;
             this._renderNoResults();
             this._eventEmitter.emit('results', res);
@@ -743,6 +754,7 @@ MapboxGeocoder.prototype = {
       ).catch(
         function(err) {
           this._hideLoadingIcon();
+          this._hideAttribution();
 
           // in the event of an error in the Mapbox Geocoding API still display results from the localGeocoder
           if ((localGeocoderRes.length && this.options.localGeocoder) || (externalGeocoderRes.length && this.options.externalGeocoder) ) {

--- a/lib/mapbox-gl-geocoder.css
+++ b/lib/mapbox-gl-geocoder.css
@@ -266,7 +266,7 @@
     color:#909090;
     padding: 6px 12px;
     font-size: 16px;
-    text-align: center
+    text-align: center;
   }
 
   .mapboxgl-ctrl-geocoder--powered-by {


### PR DESCRIPTION
The Powered by Mapbox attribution footer competes with error footers, and I propose should not be shown in the following conditions:

- An error message is returned
- No results are returned

Success response:
<img width="251" alt="image" src="https://user-images.githubusercontent.com/39810086/156824062-ca048946-fa7c-4619-8a73-a840e3554f08.png">

Error message:
<img width="252" alt="image" src="https://user-images.githubusercontent.com/39810086/156824099-026d7a4e-2beb-4dd0-9b08-386796630fc0.png">

No results:
<img width="253" alt="image" src="https://user-images.githubusercontent.com/39810086/156824134-403657d4-5fe9-4db5-b76b-c8ff91196535.png">


-------
 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
