### PR TITLE
Respect marker and flyTo options when geolocating

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -539,7 +539,7 @@ MapboxGeocoder.prototype = {
   },
 
   /**
-   * Determines whether the map should fly to a new location after geocoding.
+   * Determine whether the map should fly to a new location after geocoding.
    * @returns {Boolean} `true` if the map should fly to new locations, `false` if not
    * @private
    */

--- a/lib/index.js
+++ b/lib/index.js
@@ -331,7 +331,7 @@ MapboxGeocoder.prototype = {
         }
       };
 
-      if (this.options.marker && this._mapboxgl) {
+      if (this._shouldAddMarker()) {
         this._handleMarker(geojson);
       }
 
@@ -518,7 +518,8 @@ MapboxGeocoder.prototype = {
       if (this.options.flyTo) {
         this._fly(selected);
       }
-      if (this.options.marker && this._mapboxgl){
+
+      if (this._shouldAddMarker()) {
         this._handleMarker(selected);
       }
 
@@ -1312,6 +1313,15 @@ MapboxGeocoder.prototype = {
         .addTo(this._map);
     }
     return this;
+  },
+
+  /**
+   * Determine whether a marker should be added to the map.
+   * @returns {Boolean} `true` if a marker should be added, `false` if not
+   * @private
+   */
+  _shouldAddMarker: function() {
+    return this.options.marker && this._mapboxgl;
   },
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -292,7 +292,7 @@ MapboxGeocoder.prototype = {
       footerNode.addEventListener('mousedown', function() {
         this.selectingListItem = true;
       }.bind(this));
-    
+
       footerNode.addEventListener('mouseup', function() {
         this.selectingListItem = false;
       }.bind(this));
@@ -331,7 +331,10 @@ MapboxGeocoder.prototype = {
         }
       };
 
-      this._handleMarker(geojson);
+      if (this.options.marker && this._mapboxgl) {
+        this._handleMarker(geojson);
+      }
+
       this._fly(geojson);
 
       this._typeahead.clear();
@@ -355,11 +358,11 @@ MapboxGeocoder.prototype = {
       } else {
         this.geocoderService.reverseGeocode(config).send().then(function (resp) {
           const feature = resp.body.features[0];
-  
+
           if (feature) {
             const locationText = utils.transformFeatureToGeolocationText(feature, this.options.addressAccuracy);
             this._setInputValue(locationText);
-  
+
             feature.user_coordinates = geojson.geometry.coordinates;
             this._eventEmitter.emit('result', { result: feature });
           } else {
@@ -407,7 +410,7 @@ MapboxGeocoder.prototype = {
 
   _setInputValue: function (value) {
     this._inputEl.value = value;
-  
+
     setTimeout(function () {
       this._inputEl.focus();
       this._inputEl.scrollLeft = 0;
@@ -487,7 +490,7 @@ MapboxGeocoder.prototype = {
   _showLoadingIcon: function() {
     this._loadingEl.style.display = 'block';
   },
-  
+
   _hideLoadingIcon: function() {
     this._loadingEl.style.display = 'none';
   },
@@ -495,7 +498,7 @@ MapboxGeocoder.prototype = {
   _showAttribution: function() {
     this._footerNode.style.display = 'block'
   },
-  
+
   _hideAttribution: function() {
     this._footerNode.style.display = 'none'
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -1299,6 +1299,16 @@ MapboxGeocoder.prototype = {
     return this.options.worldview
   },
 
+
+  /**
+   * Determine whether a marker should be added to the map.
+   * @returns {Boolean} `true` if a marker should be added, `false` if not
+   * @private
+   */
+  _shouldAddMarker: function() {
+    return this.options.marker && this._mapboxgl;
+  },
+
   /**
    * Handle the placement of a result marking the selected result
    * @private
@@ -1326,15 +1336,6 @@ MapboxGeocoder.prototype = {
         .addTo(this._map);
     }
     return this;
-  },
-
-  /**
-   * Determine whether a marker should be added to the map.
-   * @returns {Boolean} `true` if a marker should be added, `false` if not
-   * @private
-   */
-  _shouldAddMarker: function() {
-    return this.options.marker && this._mapboxgl;
   },
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -335,7 +335,9 @@ MapboxGeocoder.prototype = {
         this._handleMarker(geojson);
       }
 
-      this._fly(geojson);
+      if (this._shouldFly()) {
+        this._fly(geojson);
+      }
 
       this._typeahead.clear();
       this._typeahead.selected = true;
@@ -511,11 +513,13 @@ MapboxGeocoder.prototype = {
       this._collapse();
     }
   },
+
   _onChange: function() {
     var selected = this._typeahead.selected;
     if (selected  && JSON.stringify(selected) !== this.lastSelected) {
       this._hideClearButton();
-      if (this.options.flyTo) {
+
+      if (this._shouldFly()) {
         this._fly(selected);
       }
 
@@ -532,6 +536,15 @@ MapboxGeocoder.prototype = {
       this._eventEmitter.emit('result', { result: selected });
       this.eventManager.select(selected, this);
     }
+  },
+
+  /**
+   * Determines whether the map should fly to a new location after geocoding.
+   * @returns {Boolean} `true` if the map should fly to new locations, `false` if not
+   * @private
+   */
+  _shouldFly: function() {
+    return this.options.flyTo;
   },
 
   _fly: function(selected) {

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -738,7 +738,8 @@ test('geocoder', function(tt) {
   });
 
   tt.test('options.flyTo [false] when querying', function(t){
-    t.plan(1)
+    t.plan(1);
+
     setup({
       flyTo: false
     });
@@ -780,7 +781,8 @@ test('geocoder', function(tt) {
   });
 
   tt.test('options.flyTo [true] when querying', function(t){
-    t.plan(4)
+    t.plan(4);
+
     setup({
       flyTo: true
     });

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -737,39 +737,108 @@ test('geocoder', function(tt) {
     t.end()
   });
 
-  tt.test('options.flyTo [false]', function(t){
+  tt.test('options.flyTo [false] when querying', function(t){
     t.plan(1)
     setup({
       flyTo: false
     });
 
-    var mapFlyMethod =  sinon.spy(map, "flyTo");
+    const mapFlySpy =  sinon.spy(map, 'flyTo');
+
     geocoder.query('Golden Gate Bridge');
+
     geocoder.on(
       'result',
       once(function() {
-        t.ok(mapFlyMethod.notCalled, "The map flyTo was not called when the option was set to false")
+        t.ok(mapFlySpy.notCalled, 'flyTo() was not called after querying');
       })
     );
   });
 
+  tt.test('options.flyTo [false] when geolocating', function(t) {
+    t.plan(1);
 
-  tt.test('options.flyTo [true]', function(t){
+    t.teardown(function() {
+      sinon.restore();
+    });
+
+    setup({
+      flyTo: false
+    });
+
+    stubGeolocationPosition();
+    const flyToSpy = sinon.spy(map, 'flyTo');
+
+    geocoder._geolocateUser();
+
+    geocoder.on(
+      'result',
+      once(function() {
+        t.ok(flyToSpy.notCalled, 'flyTo() was not called after geolocating');
+      })
+    );
+  });
+
+  tt.test('options.flyTo [true] when querying', function(t){
     t.plan(4)
     setup({
       flyTo: true
     });
 
-    var mapFlyMethod =  sinon.spy(map, "flyTo");
+    const flyToSpy = sinon.spy(map, "flyTo");
+
     geocoder.query('Golden Gate Bridge');
+
     geocoder.on(
       'result',
       once(function() {
-        t.ok(mapFlyMethod.calledOnce, "The map flyTo was called when the option was set to true");
-        var calledWithArgs = mapFlyMethod.args[0][0];
-        t.equals(+calledWithArgs.center[0].toFixed(4), +-122.4809.toFixed(4), 'the map is directed to fly to the right longitude');
-        t.equals(+calledWithArgs.center[1].toFixed(4),  +37.8181.toFixed(4), 'the map is directed to fly to the right latitude');
-        t.deepEqual(calledWithArgs.zoom, 16, 'the map is directed to fly to the right zoom');
+        t.ok(flyToSpy.calledOnce, 'flyTo() is called after querying');
+
+        const calledWithArgs = flyToSpy.args[0][0];
+
+        t.equals(+calledWithArgs.center[0].toFixed(4),
+          +-122.4809.toFixed(4),
+          'the map is directed to fly to the right longitude');
+
+        t.equals(+calledWithArgs.center[1].toFixed(4),
+          +37.8181.toFixed(4),
+          'the map is directed to fly to the right latitude');
+
+        t.deepEqual(calledWithArgs.zoom, 16,
+          'the map is directed to fly to the right zoom level');
+      })
+    );
+  });
+
+  tt.test('options.flyTo [true] when geolocating', function(t) {
+    t.plan(4);
+
+    t.teardown(function() {
+      sinon.restore();
+    });
+
+    setup({
+      flyTo: true
+    });
+
+    const geolocationPositionStub = stubGeolocationPosition();
+    const flyToSpy = sinon.spy(map, 'flyTo');
+
+    geocoder._geolocateUser();
+
+    geocoder.on(
+      'result',
+      once(function() {
+        t.ok(flyToSpy.calledOnce, 'flyTo() is called after geolocating');
+        const calledWithArgs = flyToSpy.args[0][0];
+        t.equals(+calledWithArgs.center[0].toFixed(4),
+          +geolocationPositionStub.coords.longitude.toFixed(4),
+          'the map is directed to fly to the right longitude');
+        t.equals(+calledWithArgs.center[1].toFixed(4),
+          +geolocationPositionStub.coords.latitude.toFixed(4),
+          'the map is directed to fly to the right latitude');
+        t.deepEqual(calledWithArgs.zoom, 16,
+          'the map is directed to fly to the right zoom level');
       })
     );
   });
@@ -892,8 +961,12 @@ test('geocoder', function(tt) {
         t.ok(markerConstructorSpy.calledOnce, 'a new marker is added to the map');
         const calledWithOptions = markerConstructorSpy.args[0][0];
         t.equals(calledWithOptions.color, '#4668F2', 'a default color is set');
-        t.equals(geolocationPositionStub.coords.latitude, event.result.user_coordinates[1], 'the marker is placed at the correct latitude');
-        t.equals(geolocationPositionStub.coords.longitude, event.result.user_coordinates[0], 'the marker is placed at the correct longitude');
+        t.equals(+event.result.user_coordinates[1].toFixed(4),
+          +geolocationPositionStub.coords.latitude.toFixed(4),
+          'the marker is placed at the correct latitude');
+        t.equals(+event.result.user_coordinates[0].toFixed(4),
+          +geolocationPositionStub.coords.longitude.toFixed(4),
+          'the marker is placed at the correct longitude');
       })
     );
   });

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -26,6 +26,26 @@ test('geocoder', function(tt) {
     map.addControl(geocoder);
   }
 
+  function stubGeolocationPosition() {
+    const geolocationPositionStub = {
+      coords: {
+        accuracy: 10,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        latitude: 38.8999242,
+        longitude: -77.0361813,
+        speed: null
+      },
+      timestamp: new Date('2022-01-01T00:00:00Z')
+    };
+
+    sinon.replace(geocoder.geolocation, 'getCurrentPosition',
+      sinon.fake.resolves(geolocationPositionStub));
+
+    return geolocationPositionStub;
+  }
+
   tt.test('initialized', function(t) {
     setup();
     t.ok(geocoder, 'geocoder is initialized');
@@ -861,21 +881,7 @@ test('geocoder', function(tt) {
       mapboxgl: mapboxgl
     });
 
-    const geolocationPositionStub = {
-      coords: {
-        accuracy: 10,
-        altitude: null,
-        altitudeAccuracy: null,
-        heading: null,
-        latitude: 38.8999242,
-        longitude: -77.0361813,
-        speed: null
-      },
-      timestamp: new Date('2022-01-01T00:00:00Z')
-    };
-    sinon.replace(geocoder.geolocation, 'getCurrentPosition',
-      sinon.fake.resolves(geolocationPositionStub));
-
+    const geolocationPositionStub = stubGeolocationPosition();
     const markerConstructorSpy = sinon.spy(mapboxgl, 'Marker');
 
     geocoder._geolocateUser();
@@ -948,21 +954,7 @@ test('geocoder', function(tt) {
       marker: false
     });
 
-    const geolocationPositionStub = {
-      coords: {
-        accuracy: 10,
-        altitude: null,
-        altitudeAccuracy: null,
-        heading: null,
-        latitude: 38.8999242,
-        longitude: -77.0361813,
-        speed: null
-      },
-      timestamp: new Date('2022-01-01T00:00:00Z')
-    };
-    sinon.replace(geocoder.geolocation, 'getCurrentPosition',
-      sinon.fake.resolves(geolocationPositionStub));
-
+    stubGeolocationPosition();
     const markerConstructorSpy = sinon.spy(mapboxgl, 'Marker');
 
     geocoder._geolocateUser();

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -830,13 +830,17 @@ test('geocoder', function(tt) {
       'result',
       once(function() {
         t.ok(flyToSpy.calledOnce, 'flyTo() is called after geolocating');
+
         const calledWithArgs = flyToSpy.args[0][0];
+
         t.equals(+calledWithArgs.center[0].toFixed(4),
           +geolocationPositionStub.coords.longitude.toFixed(4),
           'the map is directed to fly to the right longitude');
+
         t.equals(+calledWithArgs.center[1].toFixed(4),
           +geolocationPositionStub.coords.latitude.toFixed(4),
           'the map is directed to fly to the right latitude');
+
         t.deepEqual(calledWithArgs.zoom, 16,
           'the map is directed to fly to the right zoom level');
       })

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -787,7 +787,7 @@ test('geocoder', function(tt) {
       flyTo: true
     });
 
-    const flyToSpy = sinon.spy(map, "flyTo");
+    const flyToSpy = sinon.spy(map, 'flyTo');
 
     geocoder.query('Golden Gate Bridge');
 

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -965,11 +965,15 @@ test('geocoder', function(tt) {
       'result',
       once(function(event) {
         t.ok(markerConstructorSpy.calledOnce, 'a new marker is added to the map');
+
         const calledWithOptions = markerConstructorSpy.args[0][0];
+
         t.equals(calledWithOptions.color, '#4668F2', 'a default color is set');
+
         t.equals(+event.result.user_coordinates[1].toFixed(4),
           +geolocationPositionStub.coords.latitude.toFixed(4),
           'the marker is placed at the correct latitude');
+
         t.equals(+event.result.user_coordinates[0].toFixed(4),
           +geolocationPositionStub.coords.longitude.toFixed(4),
           'the marker is placed at the correct longitude');


### PR DESCRIPTION
I noticed that the geolocation feature (added in #444) adds a marker to the map and flies the map to the new location, even if the `marker` and `flyTo` options are set to `false`. This PR changes that behavior to be consistent with `query()`. I also performed some minor cleanup on some of the related tests, and removed some hanging whitespace.

I considered further DRYing those option checks and moving them into `_handleMarker()` and `_fly()`, but decided to keep that a concern of the caller, rather than those functions themselves. I don't feel strongly about it either way, though.

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
