### PR TITLE
Update Carmen link to docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -679,7 +679,7 @@ Returns **[object][75]**
 
 [85]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[86]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+[86]: https://docs.mapbox.com/api/search/geocoding/#geocoding-response-object
 
 [87]: https://docs.mapbox.com/api/search/#endpoints
 


### PR DESCRIPTION
This updates the link to Carmen GeoJSON reference to lead to the [docs page](https://docs.mapbox.com/api/search/geocoding/#geocoding-response-object) because [carmen repo](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) is private now.

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
