### PR TITLE
Make "No results found" configurable via configs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,7 @@ function getFooterNode() {
  * @param {String} [options.worldview="us"] Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
  * @param {Boolean} [options.enableGeolocation=false] If `true` enable user geolocation feature.
  * @param {('address'|'street'|'place'|'country')} [options.addressAccuracy="street"] The accuracy for the geolocation feature with which we define the address line to fill. The browser API returns the user's position with accuracy, and sometimes we can get the neighbor's address. To prevent receiving an incorrect address, you can reduce the accuracy of the definition.
+ * @param {String} [options.noResultsLabel="No results found"] Text to display if no results have been found.
  * @example
  * var geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken });
  * map.addControl(geocoder);
@@ -888,7 +889,7 @@ MapboxGeocoder.prototype = {
   },
 
   _renderNoResults: function(){
-    var errorMessage = "<div class='mapbox-gl-geocoder--error mapbox-gl-geocoder--no-results'>No results found</div>";
+    var errorMessage = `<div class='mapbox-gl-geocoder--error mapbox-gl-geocoder--no-results'>${this.options.noResultsLabel || 'No results found'}</div>`;
     this._renderMessage(errorMessage);
   },
 


### PR DESCRIPTION
This should add a dynamic label for "No results found", related to #328 

Disclaimer: not tested, just a walk by fix, hopefully it fits

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
