### PR TITLE
Fix setPlaceholder to update this.options.placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## HEAD
 
+## 5.0.2
+
+### Bug fixes 🐛
+
+- Fix `setPlaceholder` so that when `setPlaceholder` is called afterwards it return updated placeholder string [#502](https://github.com/mapbox/mapbox-gl-geocoder/pull/502)
+
 ## 5.0.1
 
 ### Bug fixes 🐛

--- a/lib/index.js
+++ b/lib/index.js
@@ -1058,9 +1058,9 @@ MapboxGeocoder.prototype = {
    * @returns {MapboxGeocoder} this
    */
   setPlaceholder: function(placeholder){
-    this.placeholder = (placeholder) ? placeholder : this._getPlaceholderText();
-    this._inputEl.placeholder = this.placeholder;
-    this._inputEl.setAttribute('aria-label', this.placeholder);
+    this.options.placeholder = (placeholder) ? placeholder : this._getPlaceholderText();
+    this._inputEl.placeholder = this.options.placeholder;
+    this._inputEl.setAttribute('aria-label', this.options.placeholder);
     return this
   },
 

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -959,6 +959,7 @@ test('geocoder', function(tt) {
     t.equals(geocoder._inputEl.placeholder, 'Test', 'the right placeholder is set on initialization');
     geocoder.setPlaceholder('Search');
     t.equals(geocoder._inputEl.placeholder, 'Search', 'the placeholder was changed in the  UI element');
+    t.equals(geocoder.getPlaceholder(), 'Search', 'the placeholder returned from getPlaceholder is the right value');
     t.end();
   });
 


### PR DESCRIPTION
Fix `setPlaceholder` so that when `setPlaceholder` is called afterwards it return updated placeholder string

### Before
Example of the bug and what this PR tries to fix:

```js
const geocoder = new MapboxGeocoder({
    accessToken: mapboxgl.accessToken,
    mapboxgl: mapboxgl,
    placeholder: 'Test'
});

geocoder.getPlaceholder();
// returns Test"

geocoder.setPlaceholder('New string');

geocoder.getPlaceholder();
// returns  "Test"  and not the updated placeholder text
```

### After

```js
const geocoder = new MapboxGeocoder({
    accessToken: mapboxgl.accessToken,
    mapboxgl: mapboxgl,
    placeholder: 'Test'
});

geocoder.getPlaceholder();
// returns  "Test"

geocoder.setPlaceholder('New string');

geocoder.getPlaceholder();
// returns  "New string" 
```

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
