### PR TITLE
GeoCoder API: missing line break in MD list

### DIFF
--- a/API.md
+++ b/API.md
@@ -472,7 +472,8 @@ Subscribe to events that happen within the plugin.
 
 #### Parameters
 
-*   `type` **[String][76]** name of event. Available events and the data passed into their respective event objects are:*   **clear** `Emitted when the input is cleared`
+*   `type` **[String][76]** name of event. Available events and the data passed into their respective event objects are:
+    *   **clear** `Emitted when the input is cleared`
     *   **loading** `{ query } Emitted when the geocoder is looking up a query`
     *   **results** `{ results } Fired when the geocoder returns a response`
     *   **result** `{ result } Fired when input is set`


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] **run `npm run docs` and commit changes to API.md** oops
 - [ ] update CHANGELOG.md with changes under `master` heading before merging

TODO: find out what causes this bug in `documentation.js`