### PR TITLE
Update event schema

### DIFF
--- a/API.md
+++ b/API.md
@@ -111,16 +111,16 @@ A geocoder component using the [Mapbox Geocoding API][74]
     *   `options.minLength` **[Number][79]** Minimum number of characters to enter before results are shown. (optional, default `2`)
     *   `options.limit` **[Number][79]** Maximum number of results to show. (optional, default `5`)
     *   `options.language` **[string][76]?** Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas. Defaults to the browser's language settings.
-    *   `options.filter` **[Function][85]?** A function which accepts a Feature in the [Carmen GeoJSON][86] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
-    *   `options.localGeocoder` **[Function][85]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON][86] format.
-    *   `options.externalGeocoder` **[Function][85]?** A function accepting the query string and current features list which performs geocoding to supplement results from the Mapbox Geocoding API. Expected to return a Promise which resolves to an Array of GeoJSON Features in the [Carmen GeoJSON][86] format.
+    *   `options.filter` **[Function][85]?** A function which accepts a Feature in the [extended GeoJSON][86] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+    *   `options.localGeocoder` **[Function][85]?** A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [extended GeoJSON][86] format.
+    *   `options.externalGeocoder` **[Function][85]?** A function accepting the query string and current features list which performs geocoding to supplement results from the Mapbox Geocoding API. Expected to return a Promise which resolves to an Array of GeoJSON Features in the [extended GeoJSON][86] format.
     *   `options.reverseMode` **(distance | score)** Set the factors that are used to sort nearby results. (optional, default `distance`)
     *   `options.reverseGeocode` **[boolean][80]** If `true`, enable reverse geocoding mode. In reverse geocoding, search input is expected to be coordinates in the form `lat, lon`, with suggestions being the reverse geocodes. (optional, default `false`)
     *   `options.flipCoordinates` **[boolean][80]** If `true`, search input coordinates for reverse geocoding is expected to be in the form `lon, lat` instead of the default `lat, lon`. (optional, default `false`)
     *   `options.enableEventLogging` **[Boolean][80]** Allow Mapbox to collect anonymous usage statistics from the plugin. (optional, default `true`)
     *   `options.marker` **([Boolean][80] | [Object][75])** If `true`, a [Marker][78] will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set. (optional, default `true`)
-    *   `options.render` **[Function][85]?** A function that specifies how the results should be rendered in the dropdown menu. This function should accepts a single [Carmen GeoJSON][86] object as input and return a string. Any HTML in the returned string will be rendered.
-    *   `options.getItemValue` **[Function][85]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][86] object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
+    *   `options.render` **[Function][85]?** A function that specifies how the results should be rendered in the dropdown menu. This function should accepts a single [extended GeoJSON][86] object as input and return a string. Any HTML in the returned string will be rendered.
+    *   `options.getItemValue` **[Function][85]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [extended GeoJSON][86] object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
     *   `options.mode` **[String][76]** A string specifying the geocoding [endpoint][87] to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes. (optional, default `mapbox.places`)
     *   `options.localGeocoderOnly` **[Boolean][80]** If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Mapbox API with the `localGeocoder` results ranked higher. (optional, default `false`)
     *   `options.autocomplete` **[Boolean][80]** Specify whether to return autocomplete results or not. When autocomplete is enabled, results will be included that start with the requested string, rather than just responses that match it exactly. (optional, default `true`)
@@ -186,7 +186,7 @@ Set input
 #### Parameters
 
 *   `searchInput` **[string][76]** location name or other search input
--   `showSuggestions` **[boolean][80]** display suggestion on setInput call (optional, default `false`)
+*   `showSuggestions` **[boolean][80]** display suggestion on setInput call (optional, default `false`)
 
 Returns **[MapboxGeocoder][2]** this
 
@@ -213,7 +213,7 @@ Set the render function used in the results dropdown
 
 #### Parameters
 
-*   `fn` **[Function][85]** The function to use as a render function. This function accepts a single [Carmen GeoJSON][86] object as input and returns a string.
+*   `fn` **[Function][85]** The function to use as a render function. This function accepts a single [extended GeoJSON][86] object as input and returns a string.
 
 Returns **[MapboxGeocoder][2]** this
 
@@ -380,7 +380,7 @@ Set the filter function used by the plugin.
 
 #### Parameters
 
-*   `filter` **[Function][85]** A function which accepts a Feature in the [Carmen GeoJSON][86] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+*   `filter` **[Function][85]** A function which accepts a Feature in the [extended GeoJSON][86] format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
 
 Returns **[MapboxGeocoder][2]** this
 
@@ -681,7 +681,7 @@ Returns **[object][75]**&#x20;
 
 [85]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[86]: https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+[86]: https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object
 
 [87]: https://docs.mapbox.com/api/search/#endpoints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## HEAD
 
+### Features / Improvements 🚀
+
+- Updates event service to latest schema
+
+### Dependency update
+
+- Bumps `mapbox-sdk-js` to v0.16.1
+
 ## 5.0.2
 
 ### Bug fixes 🐛

--- a/lib/events.js
+++ b/lib/events.js
@@ -386,7 +386,12 @@ MapboxEventManager.prototype = {
    * @returns 
    */
   objectHasRequiredProps: function(obj, requiredProps) {
-    return requiredProps.every(prop => obj[prop] !== undefined);
+    return requiredProps.every(function(prop) {
+      if (prop === 'queryString') {
+        return typeof obj[prop] === 'string' && obj[prop].length > 0;
+      }
+      return obj[prop] !== undefined;
+    });
   },
 
   /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -397,10 +397,6 @@ MapboxEventManager.prototype = {
   shouldEnableLogging: function(options){
     if (options.enableEventLogging === false) return false;
     if (options.origin && options.origin !== 'https://api.mapbox.com') return false;
-    // hard to make sense of events when a local instance is suplementing results from origin
-    if (options.localGeocoder) return false;
-    // hard to make sense of events when a custom filter is in use
-    if (options.filter) return false;
     return true;
   },
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -14,7 +14,8 @@ function MapboxEventManager(options) {
   this.endpoint = 'events/v2';
   this.access_token = options.accessToken;
   this.version = '0.3.0'
-  this.sessionID = this.generateSessionID();
+  this.pluginSessionID = this.generateSessionID();
+  this.sessionIncrementer = 0;
   this.userAgent = this.getUserAgent();
 
   this.options = options;
@@ -177,7 +178,7 @@ MapboxEventManager.prototype = {
       event: event,
       version: this.getEventSchemaVersion(event),
       created: +new Date(),
-      sessionIdentifier: this.sessionID,
+      sessionIdentifier: this.getSessionId(),
       country: this.countries,
       userAgent: this.userAgent,
       language: this.language,
@@ -281,6 +282,15 @@ MapboxEventManager.prototype = {
    */
   generateSessionID: function () {
     return nanoid();
+  },
+
+  /**
+   * Get the a unique session ID for the current plugin session and increment the session counter.
+   *
+   * @returns {String} The session ID
+   */
+  getSessionId: function(){
+    return this.pluginSessionID + '.' + this.sessionIncrementer;
   },
 
   /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -13,7 +13,7 @@ function MapboxEventManager(options) {
   this.origin = options.origin || 'https://api.mapbox.com';
   this.endpoint = 'events/v2';
   this.access_token = options.accessToken;
-  this.version = '0.2.0'
+  this.version = '0.3.0'
   this.sessionID = this.generateSessionID();
   this.userAgent = this.getUserAgent();
 
@@ -48,18 +48,14 @@ MapboxEventManager.prototype = {
      * @returns {Promise}
      */
   select: function(selected, geocoder){
-    var resultIndex = this.getSelectedIndex(selected, geocoder);
-    var payload = this.getEventPayload('search.select', geocoder);
-    payload.resultIndex = resultIndex;
-    payload.resultPlaceName  = selected.place_name;
-    payload.resultId = selected.id;
-    if ((resultIndex === this.lastSentIndex && payload.queryString === this.lastSentInput) || resultIndex == -1) {
+    var payload = this.getEventPayload('search.select', geocoder, { selectedFeature: selected });
+    if (!payload) return; // reject malformed event
+    if ((payload.resultIndex === this.lastSentIndex && payload.queryString === this.lastSentInput) || payload.resultIndex == -1) {
       // don't log duplicate events if the user re-selected the same feature on the same search
       return;
     }
-    this.lastSentIndex = resultIndex;
+    this.lastSentIndex = payload.resultIndex;
     this.lastSentInput = payload.queryString;
-    if (!payload.queryString) return; // will be rejected
     return this.push(payload)
   },
 
@@ -72,7 +68,7 @@ MapboxEventManager.prototype = {
      */
   start: function(geocoder){
     var payload = this.getEventPayload('search.start', geocoder);
-    if (!payload.queryString) return; // will be rejected
+    if (!payload) return; // reject malformed event
     return this.push(payload);
   },
 
@@ -91,9 +87,8 @@ MapboxEventManager.prototype = {
     // don't send events for keys that don't change the input
     // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
     if (keyEvent.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(keyEvent.keyCode) !== -1) return;
-    var payload = this.getEventPayload('search.keystroke', geocoder);
-    payload.lastAction = keyEvent.key;
-    if (!payload.queryString) return; // will be rejected
+    var payload = this.getEventPayload('search.keystroke', geocoder, { key: keyEvent.key });
+    if (!payload) return; // reject malformed event
     return this.push(payload);
   },
 
@@ -146,9 +141,20 @@ MapboxEventManager.prototype = {
    * @private
    * @param {String} event the name of the event to send to the events service. Valid options are 'search.start', 'search.select', 'search.feedback'.
    * @param {Object} geocoder a mapbox-gl-geocoder instance
+   * @param {Object} eventArgs Additional arguments needed for certain event types
+   * @param {Object} eventArgs.key The key pressed by the user
+   * @param {Object} eventArgs.selectedFeature GeoJSON Feature selected by the user
    * @returns {Object} an event payload
    */
-  getEventPayload: function (event, geocoder) {
+  getEventPayload: function (event, geocoder, eventArgs = {}) {
+    // Make sure required arguments are present for certain event types
+    if (
+      (event === 'search.select' && !eventArgs.selectedFeature) ||
+      (event === 'search.keystroke' && !eventArgs.key)
+    ) {
+      return null;
+    }
+
     // Handle proximity, whether null, lat/lng coordinate object, or 'ip'
     var proximity;
     if (!geocoder.options.proximity) {
@@ -156,7 +162,12 @@ MapboxEventManager.prototype = {
     } else if (typeof geocoder.options.proximity === 'object') {
       proximity = [geocoder.options.proximity.longitude, geocoder.options.proximity.latitude];
     } else if (geocoder.options.proximity === 'ip') {
-      proximity = [999,999];  // Alias for 'ip' in event logs
+      var ipProximityHeader = geocoder._headers ? geocoder._headers['ip-proximity'] : null;
+      if (ipProximityHeader) {
+        proximity = ipProximityHeader.split(',').map(parseFloat);
+      } else {
+        proximity = [999,999];  // Alias for 'ip' in event logs
+      }
     } else {
       proximity = geocoder.options.proximity;
     }
@@ -164,6 +175,7 @@ MapboxEventManager.prototype = {
     var zoom = (geocoder._map) ? geocoder._map.getZoom() : undefined;
     var payload = {
       event: event,
+      version: this.getEventSchemaVersion(event),
       created: +new Date(),
       sessionIdentifier: this.sessionID,
       country: this.countries,
@@ -185,11 +197,43 @@ MapboxEventManager.prototype = {
     // get the text in the search bar
     if (event === "search.select"){
       payload.queryString = geocoder.inputString;
-    }else if (event != "search.select" && geocoder._inputEl){
+    } else if (event != "search.select" && geocoder._inputEl){
       payload.queryString = geocoder._inputEl.value;
-    }else{
+    } else {
       payload.queryString = geocoder.inputString;
     }
+
+    // add additional properties for certain event types
+    if (['search.keystroke', 'search.select'].includes(event)) {
+      payload.path = 'geocoding/v5/mapbox.places';
+    }
+    if (event === 'search.keystroke' && eventArgs.key) {
+      payload.lastAction = eventArgs.key;
+    } else if (event === 'search.select' && eventArgs.selectedFeature) {
+      var selected = eventArgs.selectedFeature;
+      var resultIndex = this.getSelectedIndex(selected, geocoder);
+      payload.resultIndex = resultIndex;
+      payload.resultPlaceName = selected.place_name;
+      payload.resultId = selected.id;
+      if (selected.properties) {
+        payload.resultMapboxId = selected.properties.mapbox_id;
+      }
+      if (geocoder._typeahead) {
+        var results = geocoder._typeahead.data;
+        if (results && results.length > 0) {
+          payload.suggestionIds = this.getSuggestionIds(results);
+          payload.suggestionNames = this.getSuggestionNames(results);
+          payload.suggestionTypes = this.getSuggestionTypes(results);
+          payload.suggestionSources = this.getSuggestionSources(results);
+        }
+      }
+    }
+
+    // Finally, validate that required properties are present for API compatibility
+    if (!this.validatePayload(payload)) {
+      return null;
+    }
+
     return payload;
   },
 
@@ -263,6 +307,86 @@ MapboxEventManager.prototype = {
     });
     var selectedIdx = resultIDs.indexOf(selectedID);
     return selectedIdx;
+  },
+
+  getSuggestionIds: function (results) {
+    return results.map(function (feature) {
+      if (feature.properties) {
+        return feature.properties.mapbox_id || '';
+      }
+      return feature.id || '';
+    });
+  },
+
+  getSuggestionNames: function (results) {
+    return results.map(function (feature) {
+      return feature.place_name || '';
+    });
+  },
+  
+  getSuggestionTypes: function (results) {
+    return results.map(function (feature) {
+      if (feature.place_type && Array.isArray(feature.place_type)) {
+        return feature.place_type[0] || '';
+      }
+      return '';
+    });
+  },
+  
+  getSuggestionSources: function (results) {
+    return results.map(function (feature) {
+      return feature._source || '';
+    });
+  },
+
+  /**
+   * Get the correct schema version for the event
+   * @private
+   * @param {String} event Name of the event
+   * @returns 
+   */
+  getEventSchemaVersion: function(event) {
+    if (['search.keystroke', 'search.select'].includes(event)) {
+      return '2.2';
+    } else {
+      return '2.0';
+    }
+  },
+
+  /**
+   * Checks if a payload has all the required properties for the event type
+   * @private
+   * @param {Object} payload 
+   * @returns 
+   */
+  validatePayload: function(payload) {
+    if (!payload || !payload.event) return false;
+
+    var searchStartRequiredProps = ['event', 'created', 'sessionIdentifier', 'queryString'];
+    var searchKeystrokeRequiredProps = ['event', 'created', 'sessionIdentifier', 'queryString', 'lastAction'];
+    var searchSelectRequiredProps = ['event', 'created', 'sessionIdentifier', 'queryString', 'resultIndex', 'path', 'suggestionIds'];
+
+    var event = payload.event;
+    if (event === 'search.start') {
+      return this.objectHasRequiredProps(payload, searchStartRequiredProps);
+    } else if (event === 'search.keystroke') {
+      return this.objectHasRequiredProps(payload, searchKeystrokeRequiredProps);
+    } else if (event === 'search.select') {
+      return this.objectHasRequiredProps(payload, searchSelectRequiredProps);
+    }
+
+    return true;
+  },
+
+  /**
+   * Checks of an object has all the required properties
+   * @private
+   * @param {Object} obj 
+   * @param {Array<String>} requiredProps 
+   * @returns 
+   */
+  objectHasRequiredProps: function(obj, requiredProps) {
+    return requiredProps.every(prop => obj[prop] !== undefined);
   },
 
   /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -164,7 +164,7 @@ MapboxEventManager.prototype = {
       proximity = [geocoder.options.proximity.longitude, geocoder.options.proximity.latitude];
     } else if (geocoder.options.proximity === 'ip') {
       var ipProximityHeader = geocoder._headers ? geocoder._headers['ip-proximity'] : null;
-      if (ipProximityHeader) {
+      if (ipProximityHeader && typeof ipProximityHeader === 'string') {
         proximity = ipProximityHeader.split(',').map(parseFloat);
       } else {
         proximity = [999,999];  // Alias for 'ip' in event logs

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,16 +58,16 @@ function getFooterNode() {
  * @param {Number} [options.minLength=2] Minimum number of characters to enter before results are shown.
  * @param {Number} [options.limit=5] Maximum number of results to show.
  * @param {string} [options.language] Specify the language to use for response text and query result weighting. Options are IETF language tags comprised of a mandatory ISO 639-1 language code and optionally one or more IETF subtags for country or script. More than one value can also be specified, separated by commas. Defaults to the browser's language settings.
- * @param {Function} [options.filter] A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
- * @param {Function} [options.localGeocoder] A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
- * @param {Function} [options.externalGeocoder] A function accepting the query string and current features list which performs geocoding to supplement results from the Mapbox Geocoding API. Expected to return a Promise which resolves to an Array of GeoJSON Features in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format.
+ * @param {Function} [options.filter] A function which accepts a Feature in the [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+ * @param {Function} [options.localGeocoder] A function accepting the query string which performs local geocoding to supplement results from the Mapbox Geocoding API. Expected to return an Array of GeoJSON Features in the [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) format.
+ * @param {Function} [options.externalGeocoder] A function accepting the query string and current features list which performs geocoding to supplement results from the Mapbox Geocoding API. Expected to return a Promise which resolves to an Array of GeoJSON Features in the [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) format.
  * @param {distance|score} [options.reverseMode=distance] - Set the factors that are used to sort nearby results.
  * @param {boolean} [options.reverseGeocode=false] If `true`, enable reverse geocoding mode. In reverse geocoding, search input is expected to be coordinates in the form `lat, lon`, with suggestions being the reverse geocodes.
  * @param {boolean} [options.flipCoordinates=false] If `true`, search input coordinates for reverse geocoding is expected to be in the form `lon, lat` instead of the default `lat, lon`.
  * @param {Boolean} [options.enableEventLogging=true] Allow Mapbox to collect anonymous usage statistics from the plugin.
  * @param {Boolean|Object} [options.marker=true]  If `true`, a [Marker](https://docs.mapbox.com/mapbox-gl-js/api/#marker) will be added to the map at the location of the user-selected result using a default set of Marker options.  If the value is an object, the marker will be constructed using these options. If `false`, no marker will be added to the map. Requires that `options.mapboxgl` also be set.
- * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. This function should accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object as input and return a string. Any HTML in the returned string will be rendered.
- * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
+ * @param {Function} [options.render] A function that specifies how the results should be rendered in the dropdown menu. This function should accepts a single [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) object as input and return a string. Any HTML in the returned string will be rendered.
+ * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
  * @param {String} [options.mode=mapbox.places] A string specifying the geocoding [endpoint](https://docs.mapbox.com/api/search/#endpoints) to query. Options are `mapbox.places` and `mapbox.places-permanent`. The `mapbox.places-permanent` mode requires an enterprise license for permanent geocodes.
  * @param {Boolean} [options.localGeocoderOnly=false] If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Mapbox API with the `localGeocoder` results ranked higher.
  * @param {Boolean} [options.autocomplete=true] Specify whether to return autocomplete results or not. When autocomplete is enabled, results will be included that start with the requested string, rather than just responses that match it exactly.
@@ -118,6 +118,8 @@ MapboxGeocoder.prototype = {
       return '<div class="mapboxgl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title">' + placeName[0]+ '</div><div class="mapboxgl-ctrl-geocoder--suggestion-address">' + placeName.splice(1, placeName.length).join(',') + '</div></div>';
     }
   },
+  
+  _headers: {},
 
   /**
    * Add the geocoder to a container. The container can be either a `mapboxgl.Map`, an `HTMLElement` or a CSS selector string.
@@ -691,7 +693,6 @@ MapboxGeocoder.prototype = {
       .then(
         function(response) {
           this._hideLoadingIcon();
-
           var res = {};
 
           if (!response){
@@ -701,8 +702,9 @@ MapboxGeocoder.prototype = {
             }
           } else if (response.statusCode == '200') {
             res = response.body;
-            res.request = response.request
-            res.headers = response.headers
+            res.request = response.request;
+            res.headers = response.headers;
+            this._headers = response.headers;
           }
 
           res.config = config;
@@ -710,6 +712,13 @@ MapboxGeocoder.prototype = {
           if (this.fresh){
             this.eventManager.start(this);
             this.fresh = false;
+          }
+
+          // Tag Mapbox as the source for Geocoding API results, to differentiate from local or external geocoder federated results
+          if (res.features && res.features.length) {
+            res.features.map(function (feature) {
+              feature._source = 'mapbox';
+            })
           }
 
           // supplement Mapbox Geocoding API results with locally populated results

--- a/lib/index.js
+++ b/lib/index.js
@@ -659,6 +659,8 @@ MapboxGeocoder.prototype = {
     } break;
     }
 
+    config.session_token = this.eventManager.getSessionId();
+
     return config;
   },
 
@@ -801,6 +803,7 @@ MapboxGeocoder.prototype = {
     this._inputEl.value = '';
     this._typeahead.selected = null;
     this._typeahead.clear();
+    this.eventManager.sessionIncrementer++;
     this._onChange();
     this._hideClearButton();
     this._showGeolocateButton();

--- a/lib/index.js
+++ b/lib/index.js
@@ -981,7 +981,7 @@ MapboxGeocoder.prototype = {
 
   /**
    * Set the render function used in the results dropdown
-   * @param {Function} fn The function to use as a render function. This function accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object as input and returns a string.
+   * @param {Function} fn The function to use as a render function. This function accepts a single [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) object as input and returns a string.
    * @returns {MapboxGeocoder} this
    */
   setRenderFunction: function(fn){
@@ -1178,7 +1178,7 @@ MapboxGeocoder.prototype = {
 
   /**
    * Set the filter function used by the plugin.
-   * @param {Function} filter A function which accepts a Feature in the [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
+   * @param {Function} filter A function which accepts a Feature in the [extended GeoJSON](https://docs.mapbox.com/api/search/geocoding-v5/#geocoding-response-object) format to filter out results from the Geocoding API response before they are included in the suggestions list. Return `true` to keep the item, `false` otherwise.
    * @returns {MapboxGeocoder} this
    */
   setFilter: function(filter){

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
           "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.7"
           }
@@ -86,32 +87,6 @@
             "@babel/helper-validator-option": "^7.16.7",
             "browserslist": "^4.17.5",
             "semver": "^6.3.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.16.7",
-            "@babel/template": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-          "requires": {
-            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-module-imports": {
@@ -160,7 +135,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/helper-validator-option": {
           "version": "7.16.7",
@@ -172,6 +148,7 @@
           "version": "7.16.10",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
           "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
@@ -181,12 +158,14 @@
         "@babel/parser": {
           "version": "7.16.12",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
+          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
           "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.16.7",
             "@babel/parser": "^7.16.7",
@@ -197,6 +176,7 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
@@ -475,44 +455,9 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
           "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.7"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.16.7",
-            "@babel/template": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-          "requires": {
-            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-module-imports": {
@@ -536,12 +481,14 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.10",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
           "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
@@ -551,12 +498,14 @@
         "@babel/parser": {
           "version": "7.16.12",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
+          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
           "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.16.7",
             "@babel/parser": "^7.16.7",
@@ -567,28 +516,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -616,16 +548,6 @@
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.7"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -657,26 +579,11 @@
             "@babel/types": "^7.16.7"
           }
         },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-          "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/helper-wrap-function": {
           "version": "7.16.8",
@@ -722,28 +629,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -777,7 +667,8 @@
     "@babel/helper-string-parser": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.14.9",
@@ -805,63 +696,22 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
           "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.7"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.16.7",
-            "@babel/template": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-          "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.10",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
           "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
@@ -871,12 +721,14 @@
         "@babel/parser": {
           "version": "7.16.12",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
+          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
           "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.16.7",
             "@babel/parser": "^7.16.7",
@@ -887,28 +739,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -925,7 +760,8 @@
     "@babel/parser": {
       "version": "7.22.16",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA=="
+      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.7",
@@ -1038,16 +874,6 @@
             "@babel/highlight": "^7.16.7"
           }
         },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
@@ -1088,14 +914,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
           "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
           "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
           "requires": {
             "@babel/types": "^7.16.7"
           }
@@ -1149,7 +967,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.10",
@@ -1183,28 +1002,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -1284,16 +1086,6 @@
             "@babel/highlight": "^7.16.7"
           }
         },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
@@ -1334,14 +1126,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
           "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
           "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
           "requires": {
             "@babel/types": "^7.16.7"
           }
@@ -1395,7 +1179,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.10",
@@ -1429,28 +1214,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -1475,16 +1243,6 @@
             "@babel/highlight": "^7.16.7"
           }
         },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
@@ -1525,14 +1283,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
           "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
           "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
           "requires": {
             "@babel/types": "^7.16.7"
           }
@@ -1586,7 +1336,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.10",
@@ -1620,28 +1371,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -1909,16 +1643,6 @@
             "@babel/highlight": "^7.16.7"
           }
         },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
@@ -1944,14 +1668,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
           "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
           "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
           "requires": {
             "@babel/types": "^7.16.7"
           }
@@ -2005,7 +1721,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/highlight": {
           "version": "7.16.10",
@@ -2039,28 +1756,11 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -2433,50 +2133,6 @@
         "@babel/helper-replace-supers": "^7.16.7"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-          "requires": {
-            "@babel/highlight": "^7.16.7"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.16.7",
-            "@babel/template": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
         "@babel/helper-member-expression-to-functions": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
@@ -2514,70 +2170,21 @@
             "@babel/types": "^7.16.7"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-          "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
-        },
-        "@babel/highlight": {
-          "version": "7.16.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.16.7",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.16.12",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
-        },
-        "@babel/template": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-          "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-          "requires": {
-            "@babel/code-frame": "^7.16.7",
-            "@babel/parser": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/types": {
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -2878,16 +2485,6 @@
             "@babel/highlight": "^7.16.7"
           }
         },
-        "@babel/generator": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-          "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
-          "requires": {
-            "@babel/types": "^7.16.8",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
@@ -2928,14 +2525,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
           "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
           "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-          "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
           "requires": {
             "@babel/types": "^7.16.7"
           }
@@ -2998,7 +2587,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
         },
         "@babel/helper-validator-option": {
           "version": "7.16.7",
@@ -3109,34 +2699,17 @@
           "version": "7.16.8",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
           "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -3448,9 +3021,9 @@
       "dev": true
     },
     "@mapbox/mapbox-sdk": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.7.tgz",
-      "integrity": "sha512-JZjBsAVSBv7lX7gQPOQwftBGHIUcvL/tPKFxAL+SCT7u1n+eRH052XebOTkl28pNm7Du6DpKAs1GvgUnDcFFDQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.16.1.tgz",
+      "integrity": "sha512-dyZrmg+UL/Gp5mGG3CDbcwGSUMYYrfbd9hdp0rcA3pHSf3A9eYoXO9nFiIk6SzBwBVMzHENJz84ZHdqM0MDncQ==",
       "requires": {
         "@mapbox/fusspot": "^0.4.0",
         "@mapbox/parse-mapbox-token": "^0.2.0",
@@ -3763,16 +3336,6 @@
       "dev": true,
       "optional": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -3839,7 +3402,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "align-text": {
       "version": "0.1.4",
@@ -4205,7 +3769,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
       "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "bail": {
       "version": "2.0.2",
@@ -4363,9 +3928,9 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "combine-source-map": "~0.8.0",
         "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
         "safe-buffer": "^5.1.1",
         "through2": "^2.0.0",
         "umd": "^3.0.0"
@@ -4386,7 +3951,6 @@
       "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
         "browser-resolve": "^2.0.0",
@@ -4408,6 +3972,7 @@
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
         "insert-module-globals": "^7.0.0",
+        "JSONStream": "^1.0.3",
         "labeled-stream-splicer": "^2.0.0",
         "mkdirp-classic": "^0.5.2",
         "module-deps": "^6.2.3",
@@ -4593,7 +4158,6 @@
           "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
           "dev": true,
           "requires": {
-            "JSONStream": "^1.0.3",
             "assert": "^1.4.0",
             "browser-pack": "^6.0.1",
             "browser-resolve": "^2.0.0",
@@ -4615,6 +4179,7 @@
             "https-browserify": "^1.0.0",
             "inherits": "~2.0.1",
             "insert-module-globals": "^7.2.1",
+            "JSONStream": "^1.0.3",
             "labeled-stream-splicer": "^2.0.0",
             "mkdirp-classic": "^0.5.2",
             "module-deps": "^6.2.3",
@@ -5790,6 +5355,7 @@
           "version": "7.22.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
           "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.22.13",
             "chalk": "^2.4.2"
@@ -5799,6 +5365,7 @@
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -5867,23 +5434,6 @@
           "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
           "dev": true
         },
-        "@babel/helper-function-name": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-          "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
-          "requires": {
-            "@babel/template": "^7.22.5",
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-          "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
         "@babel/helper-module-imports": {
           "version": "7.22.15",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
@@ -5927,7 +5477,8 @@
         "@babel/helper-validator-identifier": {
           "version": "7.22.15",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-          "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ=="
+          "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+          "dev": true
         },
         "@babel/helpers": {
           "version": "7.22.15",
@@ -5944,6 +5495,7 @@
           "version": "7.22.13",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
           "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.22.5",
             "chalk": "^2.4.2",
@@ -5954,6 +5506,7 @@
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -5966,6 +5519,7 @@
           "version": "7.22.15",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
           "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.22.13",
             "@babel/parser": "^7.22.15",
@@ -5976,6 +5530,7 @@
           "version": "7.22.17",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
           "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
+          "dev": true,
           "requires": {
             "@babel/helper-string-parser": "^7.22.5",
             "@babel/helper-validator-identifier": "^7.22.15",
@@ -8086,11 +7641,11 @@
       "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "acorn-node": "^1.5.2",
         "combine-source-map": "^0.8.0",
         "concat-stream": "^1.6.1",
         "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
         "path-is-absolute": "^1.0.1",
         "process": "~0.11.0",
         "through2": "^2.0.0",
@@ -8602,7 +8157,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -8670,6 +8226,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -10426,7 +9992,6 @@
       "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "browser-resolve": "^2.0.0",
         "cached-path-relative": "^1.0.2",
         "concat-stream": "~1.6.0",
@@ -10434,6 +9999,7 @@
         "detective": "^5.2.0",
         "duplexer2": "^0.1.2",
         "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
         "parents": "^1.0.0",
         "readable-stream": "^2.0.2",
         "resolve": "^1.4.0",
@@ -12002,14 +11568,13 @@
       "integrity": "sha1-uu2PGn8I9TC2bwkUKH/KplsSRDo=",
       "dev": true,
       "requires": {
-        "sockjs": "0.3.7",
-        "sockjs-client": "*"
+        "sockjs": "0.3.7"
       },
       "dependencies": {
         "sockjs-client": {
           "version": "0.0.0-unreleasable",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         }
       }
     },
@@ -12463,6 +12028,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -12525,15 +12099,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
@@ -12891,7 +12456,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -13497,7 +13063,6 @@
           "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
           "dev": true,
           "requires": {
-            "JSONStream": "^1.0.3",
             "assert": "^1.4.0",
             "browser-pack": "^6.0.1",
             "browser-resolve": "^2.0.0",
@@ -13519,6 +13084,7 @@
             "https-browserify": "^1.0.0",
             "inherits": "~2.0.1",
             "insert-module-globals": "^7.2.1",
+            "JSONStream": "^1.0.3",
             "labeled-stream-splicer": "^2.0.0",
             "mkdirp-classic": "^0.5.2",
             "module-deps": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "uglify-js": "^2.8.29"
   },
   "dependencies": {
-    "@mapbox/mapbox-sdk": "^0.13.7",
+    "@mapbox/mapbox-sdk": "^0.16.1",
     "events": "^3.3.0",
     "lodash.debounce": "^4.0.6",
     "nanoid": "^3.1.31",

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -219,6 +219,9 @@ test('generate session id', function(assert){
   var eventsManager = new MapboxEventsManager({
     accessToken: 'abc123'
   })
+  assert.equals(eventsManager.getSessionId(), eventsManager.pluginSessionID + '.0', 'sessionId constructed from base pluginSessionId and incrementer');
+  eventsManager.sessionIncrementer++;
+  assert.equals(eventsManager.getSessionId(), eventsManager.pluginSessionID + '.1', 'sessionId correctly increments');
   assert.equals(typeof eventsManager.generateSessionID(), 'string', 'generates a string id');
   assert.notEqual(eventsManager.generateSessionID(), eventsManager.generateSessionID(), 'session id is generated randomly');
   assert.equals(eventsManager.generateSessionID().length, 21, 'generates an ID of the correct length');

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -311,6 +311,27 @@ test('should properly handle keypress events', function(assert){
   assert.end();
 });
 
+test('does not send event when queryString empty', function(assert){
+  var testEvent = {key: 'Backspace', code :'Backspace', metaKey: false, keyCode: 8, shiftKey: false};
+  var eventsManager = new MapboxEventsManager({
+    accessToken: 'abc123'
+  })
+  var sendMethod = sinon.spy(eventsManager, "send");
+  var pushMethod =  sinon.spy(eventsManager, "push");
+  var requestMethod = sinon.stub(eventsManager, "request").yields(null, {statusCode: 204});
+  var geocoder = new MapboxGeocoder({accessToken: 'abc123'});
+  geocoder.inputString = "";
+  eventsManager.keyevent(testEvent, geocoder);
+  assert.ok(requestMethod.notCalled, 'the http request was not initated');
+  assert.ok(sendMethod.notCalled, "the send method was not called");
+  assert.ok(pushMethod.notCalled, 'the event was NOT pushed to the event queue');
+  assert.equals(eventsManager.eventQueue.length, 0, 'the right number of events is in the queue');
+  sendMethod.restore();
+  pushMethod.restore();
+  requestMethod.restore();
+  assert.end();
+});
+
 test('it should properly flush events after the queue is full', function(assert){
   var eventsManager = new MapboxEventsManager({
     accessToken: 'abc123',

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -131,6 +131,24 @@ test('get event payload with geocoder options', function(assert){
   assert.end();
 });
 
+test('get event payload with geocoder options - proximity=ip', function(assert){
+  var options = {
+    accessToken: 'abc123',
+    proximity: 'ip'
+  }
+  var geocoder = new MapboxGeocoder(options);
+  geocoder._headers = { 'ip-proximity': '3,4' }
+  var eventsManager = new MapboxEventsManager(options);
+  geocoder.inputString = 'my string';
+  assert.equals(eventsManager.getEventPayload('test.event', geocoder).event, 'test.event', 'the correct event is set');
+  assert.equals(typeof eventsManager.getEventPayload('test.event', geocoder).created, 'number', 'a timestamp is set on the event');
+  assert.equals(typeof eventsManager.getEventPayload('test.event', geocoder).sessionIdentifier, 'string', 'the correct event is set');
+  assert.equals(eventsManager.getEventPayload('test.event', geocoder).endpoint, 'mapbox.places', 'the endpoint is always mapbox places');
+  assert.deepEqual(eventsManager.getEventPayload('test.event', geocoder).proximity, [3, 4], 'no proximity is set if no proximity is set on the geocoder');
+  assert.equals(eventsManager.getEventPayload('test.event', geocoder).queryString, 'my string', 'the query string is found from the geocoder');
+  assert.end();
+});
+
 test('search start event', function(assert){
   var eventsManager = new MapboxEventsManager({
     accessToken: 'abc123'

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -265,11 +265,11 @@ test('should enable logging', function(assert){
   assert.true(eventsManagerMapbox.shouldEnableLogging(mapboxOptions), 'logging is enabled when origin is mapbox');
     
   mapboxOptions.filter = function(){return true};
-  assert.false(eventsManagerMapbox.shouldEnableLogging(mapboxOptions), 'logging is disabled when a custom filter is enabled');
+  assert.true(eventsManagerMapbox.shouldEnableLogging(mapboxOptions), 'logging is disabled when a custom filter is enabled');
 
   mapboxOptions.filter = undefined;
   mapboxOptions.localGeocoder = function(){return 'abc'}
-  assert.false(eventsManagerMapbox.shouldEnableLogging(mapboxOptions), 'logging is disabled when a custom geocoder is enabled');
+  assert.true(eventsManagerMapbox.shouldEnableLogging(mapboxOptions), 'logging is disabled when a custom geocoder is enabled');
 
   assert.end();
 });

--- a/test/fixtures/sample-response.json
+++ b/test/fixtures/sample-response.json
@@ -1,0 +1,41 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "id": "address.1",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "properties": {
+          "mapbox_id": "mapboxId1"
+        },
+        "text": "Broadway",
+        "place_name": "2 Broadway, New York, NY 10005, United States"
+      },
+      {
+        "id": "address.2",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "properties": {
+          "mapbox_id": "mapboxId2"
+        },
+        "text": "Broad Street",
+        "place_name": "2 Broad Street, New York, NY 10005, United States"
+      },
+      {
+        "id": "address.3",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "properties": {
+          "mapbox_id": "mapboxId3"
+        },
+        "text": "Wall Street",
+        "place_name": "2 Wall Street, New York, NY 10005, United States"
+      }
+    ]
+  }


### PR DESCRIPTION
## Description

- Updates the event schema to version 2.2 for `keystroke` and `select` events. Added some validation to payload constructions to ensure server compatibility.
- Enable logging with filters and localGeocoder results mixed in. This is made possible by tagging a `_source` for Mapbox results to distinguish from client-added results.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
