### PR TITLE
v5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## 5.0.3
+
 ### Features / Improvements 🚀
 
 - Updates event service to latest schema

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",


### PR DESCRIPTION
 - [x] Update the [CHANGELOG.md](https://github.com/mapbox/mapbox-gl-geocoder/blob/main/CHANGELOG.md) by comparing the last release and what is on `main`. In the changelog, replace the `HEAD` heading with the to-be-released stable version.
 - [x] Update the version number in `package.json` and `package-lock.json`.