### PR TITLE
v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 5.1.0
+
+### Features / Improvements 🚀
+
 - Introduce `useBrowserFocus` option to use the browser's native focus management instead of the geocoder's custom focus management. This is useful for accessibility.
 
 ## 5.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mapbox-gl-geocoder",
-      "version": "5.0.3",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
         "@mapbox/mapbox-sdk": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-geocoder",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "description": "A geocoder control for Mapbox GL JS",
   "main": "lib/index.js",
   "unpkg": "dist/mapbox-gl-geocoder.min.js",


### PR DESCRIPTION
### Features / Improvements 🚀

- Introduce `useBrowserFocus` option to use the browser's native focus management instead of the geocoder's custom focus management. This is useful for accessibility.